### PR TITLE
Add DocString and CI/CD

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_general.md
+++ b/.github/ISSUE_TEMPLATE/bug_report_general.md
@@ -1,0 +1,25 @@
+---
+name: Bug report - Other bugs
+about: Create a report to help us improve
+
+---
+
+<!-- This template is meant for GENERAL bug reports.
+
+Please be as descriptive as possible
+-->
+
+### Expected behavior
+
+### Actual behavior
+
+### Steps to reproduce the behavior
+
+- Use code markdown `CODE` to make your code visible
+
+<!-- ADDITIONAL CONTEXT -->
+
+### Additional Logs, screenshots, source code,  configuration dump, ...
+
+Drag and drop zip archives containing the Additional info here, don't use external services or link.
+Screenshots can be directly dropped here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,18 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+### Feature
+
+- [ ] New functionality with network package processing for IoT traffic
+- [ ] Updating IoT Wireshark OUI database
+- [ ] Enhancing IoT device detection capabilities
+- [ ] Other (elaborated below)
+
+**Describe the feature you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+ <!-- Filling this template is mandatory -->
+
+**Your checklist for this pull request**
+- [ ] I've documented or updated the documentation of every function this PR changes
+- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
+
+**Detailed description**
+
+<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->
+
+...
+
+**Test plan**
+
+<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Or what test cases you added. -->
+
+...
+
+**Closing issues**
+
+<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
+
+...

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,11 @@
+Documentation:
+  - '**/*.md'
+
+Github-files:
+  - '.github/**'
+
+Tests:
+  - 'src/tests/**'
+
+Libinspector-Core:
+  - 'src/libinspector-core/**'

--- a/.github/workflows/deploy_wheel.yml
+++ b/.github/workflows/deploy_wheel.yml
@@ -1,0 +1,83 @@
+name: deploy_wheel
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  create_release:
+    runs-on: ubuntu-latest
+    outputs:
+      v-version: ${{ steps.version.outputs.v-version }}
+    steps:
+      # Can be major, minor, or patch, Update secret variable INCREMENT_TYPE in GitHub Actions Settings
+      - name: Set increment type from environment variable
+        run: |
+          if [ -z "${{ secrets.INCREMENT_TYPE }}" ]; then
+            echo "increment=major" >> $GITHUB_ENV
+          else
+            echo "increment=${{ secrets.INCREMENT_TYPE }}" >> $GITHUB_ENV
+          fi
+      - name: Get next version
+        uses: reecetech/version-increment@2024.10.1
+        id: version
+        with:
+          release_branch: main
+          use_api: true
+          increment: ${{ env.increment }}
+
+  build:
+    runs-on: ubuntu-latest
+    needs: [create_release]
+    steps:
+    - name: Checkout project sources
+      uses: actions/checkout@v4
+
+    - name: Create wheel file
+      run: |
+        python3 -m pip install --upgrade pip
+        python3 -m pip install setuptools wheel build setuptools_scm
+        PRETEND_VERSION=${{ needs.create_release.outputs.v-version }} python3 -m build --wheel .
+
+    - name: Store the IoT Core Python wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: iot-core
+        path: dist/*.whl
+        if-no-files-found: error
+
+  # This is disabled for now
+  publish-to-pypi:
+    name: Publish Python 🐍 distribution 📦 to PyPI
+    if: false
+    needs: [create_release, build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/treespace_metrics  # Replace <package-name> with your PyPI project name
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+      contents: write  # Required for creating releases
+
+    steps:
+      - name: Download all the wheel file
+        uses: actions/download-artifact@v4
+        with:
+          name: iot-core
+          path: dist/
+
+      - name: Publish distribution 📦 to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          verbose: true
+
+      - name: Upload wheel and debian packages to release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ needs.create_release.outputs.v-version }}
+          files: |
+            dist/*.whl

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,20 @@
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+# Automatically cancel any previous workflow on a new push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: true
+
+jobs:
+  triage:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/libinspector_test.yml
+++ b/.github/workflows/libinspector_test.yml
@@ -1,0 +1,57 @@
+name: libinspector_test
+
+on:
+  workflow_dispatch:
+  pull_request:
+# Run every 30 days, just to confirm that the code is still working
+  schedule:
+    - cron: '0 0 */30 * *'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        python-version: ["3.11", "3.12", "3.13"]
+
+    steps:
+    - name: Checkout project sources
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies (Linux/macOS)
+      if: runner.os != 'Windows'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest coverage ruff
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+
+    - name: Install dependencies (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest coverage ruff
+        if (Test-Path requirements.txt) { pip install -r requirements.txt }
+      shell: pwsh
+
+    # https://github.com/astral-sh/ruff
+    - name: Lint with ruff
+      run: |
+        ruff check
+
+    - name: Test with pytest and obtain code coverage
+      env:
+        GITHUB_ACTIONS: "true"
+      run: |
+        coverage run -m pytest src/tests
+
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v5
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+html/
 env/
 
 # Byte-compiled / optimized / DLL files

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,38 @@
+[build-system]
+requires = ["setuptools>=64", "wheel", "setuptools-scm>=8"]
+build-backend = "setuptools.build_meta"
+
+[project.urls]
+Homepage = "https://inspector.engineering.nyu.edu/"
+Source = "https://github.com/nyu-mlab/inspector-core-library/"
+Tracker = "https://github.com/nyu-mlab/inspector-core-library/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = [
+    "libinspector",
+    "libinspector.*"
+]
+
+[project]
+name = "libinspector-core"
+dynamic = ["version"]
+description = "Library for core functionalities of IoT Inspector"
+readme = "README.md"
+authors = [
+    { name = "Danny Huang", email = "dhuang@nyu.edu" }
+]
+license = "MIT"
+requires-python = ">=3.6"
+dependencies = [
+    "setuptools==75.8.0",
+    "netaddr==1.3.0",
+    "netifaces==0.11.0",
+    "scapy==2.6.1",
+    "requests==2.32.3",
+    "zeroconf==0.146.1",
+]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,23 @@
-from setuptools import setup, find_packages
+import setuptools
+import os
 
-# Function to read the requirements.txt file
-def parse_requirements(filename):
-    with open(filename, 'r') as file:
-        return [line.strip() for line in file if line.strip() and not line.startswith('#')]
 
-setup(
-    name='libinspector',
-    version='0.1.0',
-    author='NYU mLab',
-    author_email='your_email@example.com',
-    description='Library for core functionalities of IoT Inspector',
-    long_description=open('README.md').read(),
-    long_description_content_type='text/markdown',
-    url='https://github.com/nyu-mlab/inspector-core-library',
-    packages=find_packages(where='src'),
-    package_dir={'': 'src'},
-    package_data={
-        'libinspector': ['wireshark_oui_database.txt'],
-    },
-    classifiers=[
-        'Programming Language :: Python :: 3',
-        'License :: OSI Approved :: MIT License',
-        'Operating System :: OS Independent',
-    ],
-    python_requires='>=3.6',
-    install_requires=parse_requirements('requirements.txt'),  # Include requirements from requirements.txt
+if "PRETEND_VERSION" in os.environ:
+    version = os.environ["PRETEND_VERSION"]
+else:
+    from setuptools_scm import get_version
+    version = get_version(root='.',
+                          fallback_version="0.0.1",
+                          version_scheme="guess-next-dev",
+                          local_scheme="no-local-version")
+    version = version.partition(".dev")[0]
+    print(f"Using version: {version}")
+
+with open("README.md", "r") as fh:
+    description = fh.read()
+
+setuptools.setup(
+    long_description=description,
+    long_description_content_type="text/markdown",
+    version=version
 )

--- a/src/libinspector/__init__.py
+++ b/src/libinspector/__init__.py
@@ -1,1 +1,2 @@
 # This file is intentionally left blank.
+"""libinspector package initialization."""

--- a/src/libinspector/arp_scanner.py
+++ b/src/libinspector/arp_scanner.py
@@ -1,8 +1,26 @@
 """
-Discovers local devices via ARP scanning. Populates the devices table with devices. Constantly updates the default routes.
+ARP Scanner Module
 
-By default, all devices are inspected.
+This module is responsible for discovering devices on the local network using ARP scanning.
+It sends ARP requests to all IP addresses in the configured IP range from the host's active
+network interface. As devices respond, their presence is detected, and the devices table is
+populated or updated accordingly. The module also ensures that the default network routes
+are kept up to date as new devices are discovered.
 
+Features:
+- Scans the local network for active devices using ARP.
+- Populates and updates the devices table with discovered devices.
+- Constantly refreshes the default routes based on network changes.
+- By default, all discovered devices are set to be inspected.
+
+Typical usage:
+    This module is intended to be run periodically as a background thread by the Inspector core.
+
+Dependencies:
+    scapy, logging, global_state
+
+Functions:
+    start(): Performs an ARP scan over the configured IP range and updates device information.
 """
 import scapy.all as sc
 import logging
@@ -13,7 +31,13 @@ logger = logging.getLogger(__name__)
 
 
 def start():
+    """
+    Perform an ARP scan over the configured IP range.
 
+    For each IP address in the range, send an ARP request from the host's active interface.
+    Update the device's table and default routes as new devices are discovered.
+    All devices in the IP range are inspected by default.
+    """
     # Obtain the IP range
     with global_state.global_state_lock:
         ip_range = global_state.ip_range

--- a/src/libinspector/common.py
+++ b/src/libinspector/common.py
@@ -13,6 +13,7 @@ Typical usage:
     os_name = get_os()
 """
 import sys
+import os
 
 
 def get_os() -> str:
@@ -46,4 +47,22 @@ def get_os() -> str:
     raise RuntimeError('Unsupported operating system.')
 
 
+def is_admin() -> bool:
+    """
+    Check if the current user has administrative privileges.
 
+    Returns:
+        bool: True if the user is an administrator, False otherwise.
+
+    This function is a placeholder and should be implemented based on the specific
+    requirements of the operating system.
+    """
+    if get_os() == 'mac':
+        return os.geteuid() == 0
+    elif get_os() == 'linux':
+        return os.geteuid() == 0
+    elif get_os() == 'windows':
+        import ctypes
+        return ctypes.windll.shell32.IsUserAnAdmin()
+    else:
+        raise RuntimeError('Unsupported operating system for admin check.')

--- a/src/libinspector/common.py
+++ b/src/libinspector/common.py
@@ -1,13 +1,37 @@
 """
-Common helper functions
+Common Helper Functions.
 
+This module provides utility functions that are used throughout the Inspector project.
+Currently, it includes helpers for determining the operating system platform in a
+standardized way.
+
+Functions:
+    get_os(): Detects the current operating system and returns a normalized string.
+
+Typical usage:
+    from libinspector.common import get_os
+    os_name = get_os()
 """
 import sys
 
 
 def get_os() -> str:
-    """Returns 'mac', 'linux', or 'windows'. Raises RuntimeError otherwise."""
+    """
+    Detect the current operating system and return a normalized string identifier.
 
+    Returns:
+        str: One of 'mac', 'linux', or 'windows' depending on the detected platform.
+
+    Raises:
+        RuntimeError: If the operating system is not recognized as macOS, Linux, or Windows.
+
+    Example:
+        get_os()
+        'linux'
+
+    This function inspects `sys.platform` and maps it to a simplified OS name.
+    It is useful for writing cross-platform code that needs to branch on OS type.
+    """
     os_platform = sys.platform
 
     if os_platform.startswith('darwin'):

--- a/src/libinspector/core.py
+++ b/src/libinspector/core.py
@@ -21,6 +21,7 @@ Typical usage:
 """
 import logging
 import time
+import sys
 from . import global_state
 from . import mem_db
 from . import networking
@@ -31,6 +32,7 @@ from . import packet_processor
 from . import arp_spoof
 from . import ssdp_discovery
 from . import mdns_discovery
+from . import common
 
 LOG_FILE = 'inspector.log'
 
@@ -132,6 +134,10 @@ def main():
     Returns:
         None
     """
+    # Ensure that we are running as root
+    if not common.is_admin():
+        logger.error('[networking] Inspector must be run as root to enable IP forwarding.')
+        sys.exit(1)
 
     start_threads()
 

--- a/src/libinspector/core.py
+++ b/src/libinspector/core.py
@@ -1,3 +1,24 @@
+"""
+Inspector Core Module.
+
+This module serves as the main entry point and orchestrator for the Inspector application.
+It initializes logging, sets up the database, configures networking, and starts all core
+background threads for device discovery, packet collection, processing, spoofing, and
+network service discovery (mDNS, SSDP/UPnP). It also provides a command-line interface
+for running Inspector as a standalone application.
+
+Functions:
+    start_threads(custom_packet_callback_func=None): Initializes and starts all Inspector threads.
+    clean_up(): Disables IP forwarding and performs cleanup tasks.
+    main(): Runs Inspector as a standalone application, handling process lifecycle and shutdown.
+
+Dependencies:
+    logging, time, os, sys, global_state, mem_db, networking, safe_loop, arp_scanner,
+    packet_collector, packet_processor, arp_spoof, ssdp_discovery, mdns_discovery
+
+Typical usage:
+    python -m libinspector.core
+"""
 import logging
 import time
 from . import global_state
@@ -19,10 +40,24 @@ logger = logging.getLogger(__name__)
 
 def start_threads(custom_packet_callback_func=None):
     """
-    Main entry point if you use libinspector in your package.
+    Initialize and starts all core Inspector threads and services.
 
+    This function ensures only one instance of Inspector is running, initializes the
+    in-memory database, configures networking (including enabling IP forwarding),
+    and launches background threads for:
+      - Periodic network info updates
+      - ARP-based device discovery
+      - Packet collection and processing
+      - ARP spoofing
+      - mDNS and SSDP/UPnP device discovery
+
+    Args:
+        custom_packet_callback_func (callable, optional): A user-supplied callback function
+            to process packets. If provided, it will be used by the packet processor.
+
+    Returns:
+        None
     """
-
     # Make sure that only one single instance of Inspector core is running
     with global_state.global_state_lock:
         if global_state.inspector_started[0]:
@@ -68,14 +103,34 @@ def start_threads(custom_packet_callback_func=None):
 
 
 def clean_up():
+    """
+    Disables IP forwarding and performs any necessary cleanup before shutdown.
 
+    This function should be called before exiting the Inspector application to
+    restore system networking settings to their original state.
+
+    Args:
+        None
+
+    Returns:
+        None
+    """
     networking.disable_ip_forwarding()
 
 
 def main():
     """
-    Execute this function to start Inspector as a standalone application from the command line.
+    Run Inspector as a standalone application from the command line.
 
+    This function checks for root privileges, starts all Inspector threads,
+    and enters a loop to keep the application running until interrupted or
+    signaled to stop. Handles graceful shutdown on KeyboardInterrupt.
+
+    Args:
+        None
+
+    Returns:
+        None
     """
 
     start_threads()

--- a/src/libinspector/core.py
+++ b/src/libinspector/core.py
@@ -1,11 +1,4 @@
 import logging
-
-LOG_FILE = 'inspector.log'
-
-logging.basicConfig(filename=LOG_FILE, level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
-logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
-logger = logging.getLogger(__name__)
-
 import time
 from . import global_state
 from . import mem_db
@@ -18,6 +11,11 @@ from . import arp_spoof
 from . import ssdp_discovery
 from . import mdns_discovery
 
+LOG_FILE = 'inspector.log'
+
+logging.basicConfig(filename=LOG_FILE, level=logging.DEBUG, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.getLogger("scapy.runtime").setLevel(logging.ERROR)
+logger = logging.getLogger(__name__)
 
 def start_threads(custom_packet_callback_func=None):
     """

--- a/src/libinspector/global_state.py
+++ b/src/libinspector/global_state.py
@@ -1,6 +1,36 @@
 """
-Maintains the global state in a singleton design pattern.
+Global State Management (Singleton Pattern).
 
+This module maintains the global state for the Inspector application using a singleton-like approach.
+It provides thread-safe access to shared variables that are used across different components of the system,
+including networking information, application status flags, database connections, and packet processing queues.
+
+Features:
+- Thread-safe access to all global state variables via `global_state_lock`.
+- Stores host network information (IP, MAC, interface, gateway, IP range).
+- Manages the in-memory database connection and lock.
+- Tracks application lifecycle and inspection mode status.
+- Ensures only one instance of the Inspector core is running at a time.
+- Provides a queue for packet processing and supports a custom packet callback.
+
+Variables:
+    global_state_lock (threading.Lock): Lock for synchronizing access to global state.
+    host_ip_addr (str): Host machine's IP address.
+    host_mac_addr (str): Host machine's MAC address.
+    host_active_interface (str): Name of the active network interface.
+    gateway_ip_addr (str): Default gateway IP address.
+    ip_range (list): List of IP addresses in the local network range.
+    db_conn_and_lock (tuple or None): In-memory database connection and its lock.
+    is_running (bool): Indicates if the application is running.
+    is_inspecting (bool): Indicates if inspection mode is enabled.
+    inspector_started (list): Singleton flag to ensure only one Inspector instance.
+    inspector_started_ts (float): Timestamp when Inspector was started.
+    packet_queue (queue.Queue): Queue for packets to be processed.
+    custom_packet_callback_func (callable or None): Custom callback for packet processing.
+
+Usage:
+    Import this module and use the provided variables to access or modify global state.
+    Always acquire `global_state_lock` before accessing or modifying any global state variable.
 """
 import threading
 import queue

--- a/src/libinspector/local_config.py
+++ b/src/libinspector/local_config.py
@@ -1,10 +1,24 @@
 """
-Parsing a local configuration file (read-only).
+Local Configuration File Parser (Read-Only).
 
-The config file should be saved in JSON format as as a file named `inspector_config.json` in the same directory the script is run from.
+This module provides utility functions to read configuration values from a local JSON file,
+intended for use as a read-only configuration source for the Inspector application.
 
-If the config file is not found, or if the key is not found, or if the file is not in JSON format, or if there is any other error, the default value is returned.
+The configuration file should be named `libinspector_config.json` and located in the same
+directory from which the script is run. The module is resilient to missing files, missing
+keys, and malformed JSON: in all such cases, a user-supplied default value is returned.
 
+Features:
+- Reads configuration from a JSON file with caching for efficiency.
+- Returns default values if the file or key is missing, or if the file is not valid JSON.
+- Logs informative messages for file loading, missing files, and errors.
+
+Typical usage:
+    value = get('some_config_key', default=42)
+
+Functions:
+    get(config_key, default=None): Retrieve a configuration value by key.
+    _load_config_file(): Load and cache the configuration file as a dictionary.
 """
 import json
 import functools
@@ -19,9 +33,19 @@ CONFIG_FILE_PATH = 'libinspector_config.json'
 
 def get(config_key: str, default=None):
     """
-    Returns the value of the given configuration key.
-    If the key is not found, the default value is returned.
+    Retrieve the value for a given configuration key from the local config file.
 
+    Args:
+        config_key (str): The key to look up in the configuration file.
+        default (Any, optional): The value to return if the key is not found or if
+            the config file is missing or invalid. Defaults to None.
+
+    Returns:
+        Any: The value associated with `config_key` if present, otherwise `default`.
+
+    Example:
+        get('use_in_memory_db', default=True)
+        True
     """
     config_dict = _load_config_file()
     try:
@@ -30,13 +54,20 @@ def get(config_key: str, default=None):
         return default
 
 
-
 @functools.lru_cache(maxsize=1)
 def _load_config_file():
     """
-    Returns the contents of the config file as a dictionary.
-    If the file is not found, an empty dictionary is returned.
+    Load the configuration file and return its contents as a dictionary.
 
+    This function is cached to avoid repeated file reads. If the file is not found,
+    is not valid JSON, or any other error occurs, an empty dictionary is returned.
+
+    Returns:
+        dict: The parsed configuration dictionary, or an empty dict on error.
+
+    Logging:
+        - Logs info when the config file is loaded or not found.
+        - Logs errors for malformed JSON or unexpected exceptions.
     """
     try:
         with open(CONFIG_FILE_PATH, 'r') as fp:

--- a/src/libinspector/mdns_discovery.py
+++ b/src/libinspector/mdns_discovery.py
@@ -1,23 +1,37 @@
+"""
+mDNS Device Discovery Integration.
+
+This module provides functionality to discover devices on the local network using mDNS (Multicast DNS).
+It launches the mDNS discovery helper as a separate subprocess to avoid socket exhaustion issues
+and parses the discovered device information, saving it to the database. This approach ensures
+proper resource cleanup and compatibility with environments such as Streamlit.
+
+Functions:
+    start(): Runs mDNS discovery in a subprocess and updates the devices table with discovered metadata.
+
+Dependencies:
+    logging, json, subprocess, sys, global_state
+
+Typical usage example:
+    import libinspector.mdns_discovery
+    libinspector.mdns_discovery.start()
+"""
 import logging
 import json
 import subprocess
 import sys
-
 from . import global_state
-
 
 
 logger = logging.getLogger(__name__)
 
 
-
 def start():
     """
-    Discovers devices via mDNS. Saves the discovered devices to the `devices`
-    table (under the `metadata_json` column) in the database.
+    Discovers devices via mDNS. Saves the discovered devices to the `devices` table (under the `metadata_json` column) in the database.
 
-    Notes from Danny: I have to start the mdns_discovery_helper in a separate
-    process. I believe there is a bug in its original implementation that
+    Notes from Danny: I have to start the mdns_discovery_helper in a separate process.
+    I believe there is a bug in its original implementation that
     doesn't properly close the socket. As a result, a few minutes of continuous
     discovery will cause the OS to run out of sockets, even though I make sure
     that the zeroconf object is closed after the discovery is done. Below is a
@@ -27,6 +41,11 @@ def start():
     multiprocessing as it does not play well with `streamlit`. The only way that
     works is `subprocess`.
 
+    Args:
+        None
+
+    Returns:
+        None
     """
     logger.info("[mDNS] Discovering devices...")
 

--- a/src/libinspector/mdns_discovery_helper.py
+++ b/src/libinspector/mdns_discovery_helper.py
@@ -1,26 +1,94 @@
+"""
+mDNS Discovery Helper.
+
+This module provides utilities for discovering devices and service types on the local network
+using Multicast DNS (mDNS) via the zeroconf protocol. It includes listeners for service type
+and device discovery, as well as functions to enumerate all available mDNS service types and
+to collect device information for each discovered service.
+
+Classes:
+    ServiceTypeListener: Listener to collect available mDNS service types.
+    MDNSDeviceListener: Listener to collect device information for a specific mDNS service type.
+
+Functions:
+    get_all_service_types(timeout=15): Discover all available mDNS service types.
+    discover_mdns_devices(service_type): Discover devices for a given mDNS service type.
+    get_mdns_devices(service_type_discovery_timeout=10, device_discovery_timeout=10): Discover devices using mDNS, grouped by IP address.
+
+Dependencies:
+    zeroconf, time, json
+
+Typical usage example:
+    device_dict = get_mdns_devices(service_type_discovery_timeout=5, device_discovery_timeout=5)
+    print(json.dumps(device_dict, indent=2))
+"""
 from zeroconf import Zeroconf, ServiceBrowser, ServiceListener
 import time
 import json
 
 
-
 class ServiceTypeListener(ServiceListener):
-    """ Listener to discover available mDNS service types. """
+    """
+    Listener to discover available mDNS service types.
+
+    Attributes:
+        service_types (set): A set of discovered mDNS service type names.
+
+    Methods:
+        add_service(zeroconf, service_type, name): Called when a new service type is discovered.
+        remove_service(zeroconf, service_type, name): Called when a service type is removed.
+        update_service(zeroconf, service_type, name): Called when a service type is updated.
+    """
+
     def __init__(self):
+        """Initialize a new ServiceTypeListener with an empty set of service types."""
         self.service_types = set()
 
     def add_service(self, zeroconf, service_type, name):
+        """
+        Call when a new mDNS service type is discovered.
+
+        Args:
+            zeroconf (Zeroconf): The Zeroconf instance.
+            service_type (str): The type of the service.
+            name (str): The name of the discovered service type.
+        """
         if name not in self.service_types:
             self.service_types.add(name)
 
     def remove_service(self, zeroconf, service_type, name):
+        """
+        Call when a service type is removed.
+
+        Args:
+            zeroconf (Zeroconf): The Zeroconf instance.
+            service_type (str): The type of the service.
+            name (str): The name of the removed service type.
+        """
         print(f"[mDNS] [REMOVED SERVICE TYPE] {name}")
 
     def update_service(self, zeroconf, service_type, name):
+        """
+        Call when a service type is updated.
+
+        Args:
+            zeroconf (Zeroconf): The Zeroconf instance.
+            service_type (str): The type of the service.
+            name (str): The name of the updated service type.
+        """
         print(f"[mDNS] [UPDATED SERVICE TYPE] {name}")
 
+
 def get_all_service_types(timeout=15):
-    """ Discover all available mDNS service types. """
+    """
+    Discover all available mDNS service types on the local network.
+
+    Args:
+        timeout (int, optional): Number of seconds to wait for service discovery. Defaults to 15.
+
+    Returns:
+        set: A set of discovered mDNS service type names (str).
+    """
     zeroconf = Zeroconf()
     listener = ServiceTypeListener()
     ServiceBrowser(zeroconf, "_services._dns-sd._udp.local.", listener)
@@ -32,15 +100,42 @@ def get_all_service_types(timeout=15):
 
 
 class MDNSDeviceListener(ServiceListener):
-    """ Listener to discover devices for a specific service type. """
-    def __init__(self, service_type):
-        self.service_type = service_type
+    """
+    Listener to discover devices for a specific mDNS service type.
 
+    Atributes:
+        service_type (str): The mDNS service type being monitored.
+        device_name (str or None): The name of the discovered device.
+        device_ip_address (str or None): The IPv4 address of the discovered device.
+        device_properties (dict or None): Properties of the discovered device.
+
+    Methods:
+        add_service(zeroconf, service_type, name): Called when a new device is discovered.
+        remove_service(zeroconf, service_type, name): Called when a device is removed.
+        update_service(zeroconf, service_type, name): Called when a device is updated.
+    """
+
+    def __init__(self, service_type):
+        """
+        Initialize a new MDNSDeviceListener for a specific service type.
+
+        Args:
+            service_type (str): The mDNS service type to monitor.
+        """
+        self.service_type = service_type
         self.device_name = None
         self.device_ip_address = None
         self.device_properties = None
 
     def add_service(self, zeroconf, service_type, name):
+        """
+        Call when a new device is discovered for the monitored service type.
+
+        Args:
+            zeroconf (Zeroconf): The Zeroconf instance.
+            service_type (str): The type of the service.
+            name (str): The name of the discovered device.
+        """
         try:
             info = zeroconf.get_service_info(service_type, name)
         except Exception:
@@ -64,24 +159,57 @@ class MDNSDeviceListener(ServiceListener):
                 self.device_properties = clean_property_dict
 
     def remove_service(self, zeroconf, service_type, name):
+        """
+        Call when a device is removed.
+
+        Args:
+            zeroconf (Zeroconf): The Zeroconf instance.
+            service_type (str): The type of the service.
+            name (str): The name of the removed device.
+        """
         pass
 
     def update_service(self, zeroconf, service_type, name):
+        """
+        Call when a device is updated.
+
+        Args:
+            zeroconf (Zeroconf): The Zeroconf instance.
+            service_type (str): The type of the service.
+            name (str): The name of the updated device.
+        """
         self.device_name = name
 
 
 def discover_mdns_devices(service_type):
-    """ Discover devices for a given mDNS service type. """
+    """
+    Discover devices for a given mDNS service type.
+
+    Args:
+        service_type (str): The mDNS service type to search for devices.
+
+    Returns:
+        tuple: A tuple (zeroconf, listener) where zeroconf is the Zeroconf instance and
+        listener is the MDNSDeviceListener instance.
+    """
     zeroconf = Zeroconf()
     listener = MDNSDeviceListener(service_type)
     ServiceBrowser(zeroconf, service_type, listener)
-
-    return (zeroconf, listener)
+    return zeroconf, listener
 
 
 def get_mdns_devices(service_type_discovery_timeout=10, device_discovery_timeout=10):
-    """ Discover devices using mDNS. Returns a dictionary of devices grouped by IP address. """
+    """
+    Discover devices using mDNS and group them by IP address.
 
+    Args:
+        service_type_discovery_timeout (int, optional): Seconds to wait for service type discovery. Defaults to 10.
+        device_discovery_timeout (int, optional): Seconds to wait for device discovery per service type. Defaults to 10.
+
+    Returns:
+        dict: A dictionary mapping device IP addresses (str) to a list of dictionaries,
+        each containing 'device_name' and 'device_properties' for a discovered device.
+    """
     # Discover all available mDNS service types
     service_types = get_all_service_types(timeout=service_type_discovery_timeout)
 

--- a/src/libinspector/mdns_discovery_helper.py
+++ b/src/libinspector/mdns_discovery_helper.py
@@ -43,7 +43,7 @@ class MDNSDeviceListener(ServiceListener):
     def add_service(self, zeroconf, service_type, name):
         try:
             info = zeroconf.get_service_info(service_type, name)
-        except Exception as e:
+        except Exception:
             pass
 
         if info:
@@ -58,7 +58,7 @@ class MDNSDeviceListener(ServiceListener):
                         continue
                     try:
                         clean_property_dict[k.decode(errors='replace')] = v.decode(errors='replace')
-                    except Exception as e:
+                    except Exception:
                         pass
 
                 self.device_properties = clean_property_dict
@@ -90,7 +90,7 @@ def get_mdns_devices(service_type_discovery_timeout=10, device_discovery_timeout
     for service_type in service_types:
         try:
             zc, listener = discover_mdns_devices(service_type)
-        except Exception as e:
+        except Exception:
             continue
         zc_listener_list.append((zc, listener))
 

--- a/src/libinspector/networking.py
+++ b/src/libinspector/networking.py
@@ -141,7 +141,7 @@ def get_my_mac_set(iface_filter=None):
         if iface_filter is not None and len(iface) > 1 and iface in iface_filter:
             try:
                 mac = sc.get_if_hwaddr(iface_filter)
-            except Exception as e:
+            except Exception:
                 continue
             else:
                 out_set.add(mac)

--- a/src/libinspector/networking.py
+++ b/src/libinspector/networking.py
@@ -36,17 +36,11 @@ import scapy.all as sc
 import netifaces
 import netaddr
 import logging
-import os
 
 from . import global_state
 from . import common
 
 logger = logging.getLogger(__name__)
-
-# Ensure that we are running as root
-if os.geteuid() != 0:
-    logger.error('[networking] Inspector must be run as root to enable IP forwarding.')
-    sys.exit(1)
 
 
 def get_mac_address_from_ip(ip_addr: str) -> str:

--- a/src/libinspector/networking.py
+++ b/src/libinspector/networking.py
@@ -125,8 +125,6 @@ def get_default_route():
     Raises:
         SystemExit: If no default route is found after multiple attempts or if network connectivity is unavailable.
     """
-    # TODO: This function may not work on Windows.
-
     # Discover the active/preferred network interface
     # by connecting to Google's public DNS server
     try:
@@ -227,7 +225,6 @@ def get_network_mask():
 
     iface_str = ''
     if sys.platform.startswith('win'):
-        # TODO: Need to test on Windows
         iface_info = sc.conf.iface
         iface_str = iface_info.guid
     else:

--- a/src/libinspector/oui_parser.py
+++ b/src/libinspector/oui_parser.py
@@ -1,6 +1,28 @@
 """
-Parses and extracts the company based on the MAC address.
+OUI (Organizationally Unique Identifier) Parser Module.
 
+This module provides functionality to parse and extract the vendor or company name
+associated with a given MAC address using a Wireshark OUI database. It loads the
+OUI-to-company mapping from a resource file and efficiently caches lookups for
+performance. The main function, `get_vendor`, returns the vendor name for a given
+MAC address, or an empty string if the vendor is unknown.
+
+Key Features:
+- Loads and parses the Wireshark OUI database from a packaged resource file.
+- Supports OUI prefixes of varying lengths for accurate vendor identification.
+- Uses LRU caching to optimize repeated lookups and database parsing.
+- Provides a simple interface to retrieve the vendor for a given MAC address.
+
+Intended Usage:
+Call `get_vendor(mac_addr)` with a MAC address string to retrieve the associated
+vendor or company name.
+
+Dependencies:
+- functools
+- importlib.resources
+
+Resource File:
+- wireshark_oui_database.txt (must be present in the `libinspector` package)
 """
 import functools
 import importlib.resources
@@ -15,6 +37,28 @@ _oui_length_split_list = []
 
 @functools.lru_cache(maxsize=1)
 def parse_wireshark_oui_database():
+    """
+    Parse the Wireshark OUI database and populates the OUI-to-company mapping.
+
+    This function reads the `wireshark_oui_database.txt` resource file, which contains mappings
+    from OUI prefixes to company names, and populates the global `_oui_dict` with these mappings.
+    It also determines the set of unique OUI prefix lengths found in the database and stores them
+    in `_oui_length_split_list` for use in vendor lookups.
+
+    The function is cached to ensure the database is only parsed once per process lifetime,
+    improving performance for repeated lookups.
+
+    File Format:
+        Each line in the database file should be tab-separated, with the OUI prefix, an unused field,
+        and the company name. Lines starting with '#' or empty lines are ignored.
+
+    Side Effects:
+        - Populates the global `_oui_dict` with OUI-to-company mappings.
+        - Populates the global `_oui_length_split_list` with sorted OUI prefix lengths.
+
+    Returns:
+        None
+    """
     _oui_length_splits = set()
     with importlib.resources.files('libinspector').joinpath('wireshark_oui_database.txt').open('r', encoding='utf-8') as fp:
         for line in fp:
@@ -32,8 +76,27 @@ def parse_wireshark_oui_database():
 
 @functools.lru_cache(maxsize=1024)
 def get_vendor(mac_addr: str) -> str:
-    """Given a MAC address, returns the vendor. Returns '' if unknown. """
+    """
+    Retrieve the vendor or company name associated with a given MAC address.
 
+    This function normalizes the input MAC address by removing common delimiters and converting
+    it to lowercase. It then attempts to match the longest possible OUI prefix from the MAC address
+    against the entries in the OUI database, as loaded by `parse_wireshark_oui_database()`.
+    If a matching OUI is found, the corresponding company name is returned; otherwise, an empty
+    string is returned to indicate an unknown vendor.
+
+    The function uses LRU caching to optimize repeated lookups for the same MAC addresses.
+
+    Args:
+        mac_addr (str): The MAC address to look up. Accepts formats with colons, dashes, or dots.
+
+    Returns:
+        str: The vendor or company name associated with the MAC address, or an empty string if unknown.
+
+    Example:
+        >>> get_vendor('00:1A:2B:3C:4D:5E')
+        'Example Corp'
+    """
     parse_wireshark_oui_database()
 
     mac_addr = mac_addr.lower().replace(':', '').replace('-', '').replace('.', '')

--- a/src/libinspector/oui_parser.py
+++ b/src/libinspector/oui_parser.py
@@ -3,7 +3,7 @@ Parses and extracts the company based on the MAC address.
 
 """
 import functools
-import pkg_resources
+import importlib.resources
 
 
 # Maps the first 3 (or more) bytes of the MAC address to the company name.
@@ -15,12 +15,8 @@ _oui_length_split_list = []
 
 @functools.lru_cache(maxsize=1)
 def parse_wireshark_oui_database():
-
     _oui_length_splits = set()
-
-    wireshark_oui_db_file_path = pkg_resources.resource_filename('libinspector', 'wireshark_oui_database.txt')
-
-    with open(wireshark_oui_db_file_path, encoding='utf-8') as fp:
+    with importlib.resources.files('libinspector').joinpath('wireshark_oui_database.txt').open('r', encoding='utf-8') as fp:
         for line in fp:
             line = line.strip()
             if line == '' or line.startswith('#'):

--- a/src/libinspector/packet_collector.py
+++ b/src/libinspector/packet_collector.py
@@ -1,6 +1,25 @@
 """
-Captures and analyzes packets from the network.
+Packet Collector Module for Network Inspection.
 
+This module is responsible for capturing network packets from the active network interface
+using Scapy, filtering out irrelevant traffic, and queuing packets for further analysis.
+It provides functions to start the packet sniffing process, check the running state of
+the Inspector, and safely add packets to a shared processing queue.
+
+Key Features:
+- Captures packets in 30-second intervals to ensure robustness against crashes.
+- Excludes packets to/from the Inspector host, except for ARP packets needed for device discovery.
+- Thread-safe access to global state for interface, IP address, and control flags.
+- Periodically logs the size of the packet queue for monitoring.
+- Designed for integration with a real-time network monitoring and analysis system.
+
+Dependencies:
+- scapy
+- time
+- logging
+
+Intended Usage:
+Import and invoke `start()` to begin packet collection as part of the Inspector's workflow.
 """
 import scapy.all as sc
 import time
@@ -16,7 +35,17 @@ print_queue_size_dict = {'last_updated_ts': 0}
 
 
 def start():
+    """
+    Continuously captures network packets from the active interface and adds them to the processing queue.
 
+    This function acquires the Inspector's active network interface and IP address under a global lock,
+    then uses Scapy's `sniff` to capture packets in 30-second intervals. The sniffing filter excludes
+    packets to/from the host itself, except for ARP packets which are required for device discovery.
+    Each captured packet is passed to `add_packet_to_queue`. Sniffing stops if the Inspector is no longer running.
+
+    Returns:
+        None
+    """
     with global_state.global_state_lock:
         host_active_interface = global_state.host_active_interface
         host_ip_addr = global_state.host_ip_addr
@@ -33,10 +62,15 @@ def start():
     )
 
 
-def inspector_is_running():
+def inspector_is_running() -> bool:
     """
-    Returns whether the Inspector is running or not.
+    Check if the Inspector is currently running.
 
+    This function acquires a global lock and returns the current running state of the Inspector,
+    as indicated by the `is_running` flag in global state.
+
+    Returns:
+        bool: True if the Inspector is running, False otherwise.
     """
     with global_state.global_state_lock:
         return global_state.is_running
@@ -44,8 +78,17 @@ def inspector_is_running():
 
 def add_packet_to_queue(pkt):
     """
-    Adds a packet to the packet queue.
+    Add a captured packet to the global packet queue for processing.
 
+    This function checks if packet inspection is currently enabled. If so, it puts the packet
+    into the global queue for later processing. Additionally, it logs the current queue size
+    every 10 seconds for monitoring purposes.
+
+    Args:
+        pkt (scapy.packet.Packet): The captured network packet to be queued.
+
+    Returns:
+        None
     """
     with global_state.global_state_lock:
         if not global_state.is_inspecting:

--- a/src/libinspector/packet_processor.py
+++ b/src/libinspector/packet_processor.py
@@ -1,3 +1,11 @@
+"""
+Packet processing module for network inspection.
+
+This module provides functions to process various types of network packets
+(ARP, DHCP, DNS, TCP/UDP flows, TLS ClientHello) and update the corresponding
+database tables with device, hostname, and flow information. It is designed
+to be used by the Inspector host for real-time network monitoring and analysis.
+"""
 import time
 import scapy.all as sc
 import traceback
@@ -18,7 +26,15 @@ update_hostnames_in_flows_status_dict = {
 
 
 def start():
+    """
+    Retrieve a network packet from the global packet queue and process it.
 
+    This function obtains the next packet from the shared packet queue and passes it to the packet processing helper.
+    Any exceptions raised during processing are caught and logged with detailed traceback information for debugging.
+
+    Returns:
+        None
+    """
     pkt = global_state.packet_queue.get()
 
     try:
@@ -29,7 +45,22 @@ def start():
 
 
 def process_packet_helper(pkt):
+    """
+    Process a captured network packet and dispatch it to the appropriate handler.
 
+    This function first checks for a custom packet callback and executes it if present, logging any exceptions. It then determines the packet type and processes it accordingly:
+    - ARP and DHCP packets are handled by their respective functions and processing stops.
+    - Packets without both Ethernet and IP layers are ignored.
+    - Packets involving the Inspector host's own IP address are ignored.
+    - DNS packets are processed and then terminated.
+    - For all other packets, the function attempts to extract TLS SNI information and then processes the packet as a network flow.
+
+    Args:
+        pkt: The network packet (scapy packet) to process.
+
+    Returns:
+        None, or the result of the specific packet handler if applicable.
+    """
     with global_state.global_state_lock:
         pkt_callback_func = global_state.custom_packet_callback_func
 
@@ -73,9 +104,15 @@ def process_packet_helper(pkt):
 
 def process_arp(pkt):
     """
-    Updates ARP cache upon receiving ARP packets, only if the packet is not
-    spoofed.
+    Process an ARP packet to update the ARP cache and device information in the database.
 
+    This function handles ARP request and reply packets, ignoring those sent by the Inspector host or with a source IP of 0.0.0.0. It determines if the ARP entry corresponds to the network gateway and updates or inserts the device's MAC and IP address in the `devices` table, along with a timestamp and gateway status. Afterward, it updates the device's metadata with the OUI vendor if not already present.
+
+    Args:
+        pkt: The ARP packet (scapy packet) to process.
+
+    Returns:
+        None
     """
     if not ((pkt.op == 1 or pkt.op == 2)):
         return
@@ -122,7 +159,17 @@ def process_arp(pkt):
 
 
 def process_dns(pkt):
+    """
+    Process a DNS packet to extract the querying device, hostname, and associated IP addresses.
 
+    This code determines which device made the DNS request or response by comparing MAC addresses with the Inspector host. It ensures the device is not the gateway and extracts the queried hostname from the DNS question section, removing any trailing dot. If the packet contains DNS answers, it collects all IPv4 addresses from A records. If no IP addresses are found, an empty string is used. The extracted device MAC address, hostname, and set of IP addresses are then recorded in the database for tracking DNS activity.
+
+    Args:
+        pkt: The network packet (scapy packet) containing the DNS data.
+
+    Returns:
+        None
+    """
     src_mac_addr = pkt[sc.Ether].src
     dst_mac_addr = pkt[sc.Ether].dst
 
@@ -178,7 +225,21 @@ def process_dns(pkt):
 
 
 def write_hostname_ip_mapping_to_db(device_mac_addr, hostname, ip_set, data_source):
+    """
+    Insert or update hostname-to-IP mappings in the `hostnames` table and log the operation.
 
+    This code iterates over a set of IP addresses and, for each, inserts a new record or updates an existing one in the `hostnames` database table with the provided hostname, current timestamp, and data source. The operation is performed within a write lock to ensure thread safety. After updating the database, it logs the mapping of the device's MAC address, hostname, and associated IP addresses for traceability.
+
+    Args:
+        ip_set: Set of IP addresses to associate with the hostname.
+        hostname: The hostname to map to each IP address.
+        current_ts: The current timestamp for the update.
+        data_source: The source of the hostname information.
+        device_mac_addr: The MAC address of the device (used for logging).
+
+    Returns:
+        None
+    """
     current_ts = int(time.time())
 
     conn, rw_lock = global_state.db_conn_and_lock
@@ -197,9 +258,18 @@ def write_hostname_ip_mapping_to_db(device_mac_addr, hostname, ip_set, data_sour
     logger.info(f'[Pkt Processor] Device {device_mac_addr}: {hostname} -> {ip_set} (data_source: {data_source})')
 
 
-
 def process_flow(pkt):
+    """
+    Process a TCP or UDP packet and update the `network_flows` table with flow information.
 
+    This function inspects the given packet to determine if it contains a TCP or UDP layer. It extracts relevant flow details such as source and destination MAC addresses, IP addresses, ports, and the TCP sequence number (if applicable). The function ensures the packet is not a broadcast and that the Inspector host is involved in the communication, updating MAC addresses as needed to reflect the actual device or gateway. It then inserts or updates a record in the `network_flows` database table, incrementing byte and packet counts and updating TCP sequence number metadata. After updating the flow, it triggers a refresh of hostnames in the flow records to ensure the most current hostname information is associated with each flow.
+
+    Args:
+        pkt: The network packet (scapy packet) to process.
+
+    Returns:
+        None
+    """
     # Must have TCP or UDP layer
     if sc.TCP in pkt:
         protocol = 'tcp'
@@ -279,8 +349,12 @@ def process_flow(pkt):
 
 def update_hostnames_in_flows():
     """
-    Every 2 seconds, we replace the ip_addresses with the hostnames from the hostnames table.
+    Update the `network_flows` table by replacing IP addresses with corresponding hostnames from the `hostnames` table.
 
+    This function runs at most once every 2 seconds. It checks if enough time has passed since the last update, and if so, it acquires a database lock and executes an SQL statement to update the `src_hostname` and `dest_hostname` fields in the `network_flows` table. The update is performed only for flows where either the source or destination hostname is missing and a matching IP-to-hostname mapping exists in the `hostnames` table. After the update, the function records the current timestamp and logs the number of rows affected. This ensures that the flow records reflect the most recent hostname information for easier analysis and tracking.
+
+    Returns:
+        None
     """
     if time.time() - update_hostnames_in_flows_status_dict['last_update_ts'] < 2:
         return
@@ -321,7 +395,19 @@ def update_hostnames_in_flows():
 
 
 def process_dhcp(pkt):
+    """
+    Process a DHCP packet to extract the device hostname and update the devices table in the database.
 
+    This function checks if the given packet is a DHCP Request broadcast.
+    If so, it attempts to extract the hostname from the DHCP options.
+    If a valid hostname is found and the packet is not a response from the Inspector host itself, the function updates the devices table in the database with the device's MAC address, IP address, and hostname information. This enables tracking of devices and their hostnames on the network. If the packet does not meet these criteria or an error occurs during extraction, the function returns without making changes.
+
+    Args:
+        pkt: The network packet (scapy packet) to process.
+
+    Returns:
+        None
+    """
     # Must be a DHCP Request broadcast
     if pkt[sc.Ether].dst != 'ff:ff:ff:ff:ff:ff':
         return
@@ -363,8 +449,17 @@ def process_dhcp(pkt):
 
 
 def process_client_hello(pkt):
-    """Extracts the SNI field from the ClientHello packet."""
+    """
+    Extract the Server Name Indication (SNI) from a TLS ClientHello packet and updates the database with the mapping.
 
+    This function processes a network packet to determine if it is destined for the Inspector host. If so, it attempts to extract the SNI field from the TLS ClientHello handshake. When an SNI is found, it is converted to lowercase and associated with the source device's MAC address and the remote IP address. This information is then recorded in the database, allowing tracking of which devices are attempting to connect to which hostnames. If the packet is not destined for the Inspector host or does not contain an SNI, no action is taken.
+
+    Args:
+        pkt: The network packet (scapy packet) to process.
+
+    Returns:
+        None
+    """
     # Make sure that the Inspector host should be the destination of this packet
     with global_state.global_state_lock:
         if pkt[sc.Ether].dst != global_state.host_mac_addr:

--- a/src/libinspector/safe_loop.py
+++ b/src/libinspector/safe_loop.py
@@ -1,6 +1,5 @@
 """
-A wrapper to repeatedly execute a function in a daemon thread; if the
-function crashes, automatically restarts the function.
+A wrapper to repeatedly execute a function in a daemon thread; if the function crashes, automatically restarts the function.
 
 Usage:
 
@@ -22,9 +21,40 @@ logger = logging.getLogger(__name__)
 
 
 class SafeLoopThread(object):
+    """
+    Runs a function repeatedly in a daemon thread, automatically restarting it if it crashes.
+
+    This class creates a background thread that continuously executes the given function
+    with the provided arguments. If the function raises an exception, the error is logged,
+    and the function is restarted after an optional sleep interval.
+
+    Usage:
+        def my_func(a, b=1):
+            pass
+        SafeLoopThread(my_func, args=['a'], kwargs={'b': 2}, sleep_time=1)
+
+    Args:
+        func (callable): The function to execute repeatedly.
+        args (list, optional): Positional arguments to pass to the function. Defaults to [].
+        kwargs (dict, optional): Keyword arguments to pass to the function. Defaults to {}.
+        sleep_time (int or float, optional): Seconds to sleep between function calls. Defaults to 0.
+
+    """
 
     def __init__(self, func, args=[], kwargs={}, sleep_time=0) -> None:
+        """
+        Initialize the SafeLoopThread and starts the background daemon thread.
 
+        This constructor sets up the function and its arguments to be executed repeatedly
+        in a background thread. It does not return any value or produce side effects
+        except for starting the daemon thread that manages the repeated execution.
+
+        Args:
+            func (callable): The function to execute repeatedly in the thread.
+            args (list, optional): Positional arguments to pass to the function. Defaults to [].
+            kwargs (dict, optional): Keyword arguments to pass to the function. Defaults to {}.
+            sleep_time (int or float, optional): Seconds to sleep between function calls. Defaults to 0.
+        """
         self._func = func
         self._func_args = args
         self._func_kwargs = kwargs
@@ -35,15 +65,25 @@ class SafeLoopThread(object):
         th.start()
 
     def _execute_repeated_func_safe(self):
-        """Safely executes the repeated function calls."""
+        """
+        Repeatedly executes the target function in a loop, catching and logging any exceptions.
 
+        This method runs in a background daemon thread. It continuously calls the user-provided
+        function with the specified arguments. If the function raises an exception, the error
+        (including traceback and invocation details) is logged and written to stderr. After each
+        execution (successful or not), the method sleeps for the configured interval before
+        restarting the function.
+
+        Args:
+            None
+
+        Returns:
+            None
+        """
         while True:
-
             try:
                 self._func(*self._func_args, **self._func_kwargs)
-
             except Exception as e:
-
                 err_msg = '=' * 80 + '\n'
                 err_msg += 'Time: %s\n' % datetime.datetime.today()
                 err_msg += 'Function: %s %s %s\n' % (self._func, self._func_args, self._func_kwargs)

--- a/src/libinspector/ssdp_discovery.py
+++ b/src/libinspector/ssdp_discovery.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Discovers devices via SSDP. Returns an iterator of device_dict's.
 
 Sample usage:
@@ -154,7 +154,23 @@ ST: ssdp:all
 
 
 def start():
+    """
+    Start the SSDP discovery process and update the device database with discovered devices.
 
+    This function performs SSDP (Simple Service Discovery Protocol) discovery to find UPnP devices
+    on the local network. For each discovered device, it updates the `devices` table in the database
+    with the device's SSDP and UPnP metadata if not already present.
+
+    Side Effects:
+        - Updates the `devices` table in the database with discovered device information.
+        - Logs discovered devices using the module logger.
+
+    Args:
+        None
+
+    Returns:
+        None
+    """
     conn, rw_lock = global_state.db_conn_and_lock
 
     # Set the socket timeout based on when the Inspector started; shorter
@@ -187,9 +203,16 @@ def start():
             logger.info(f"[ssdp] Discovered device: {discovered_device_dict['device_ip_addr']}")
 
 
-
 def fetch_and_parse_xml(url):
-    """Fetch the XML from the given URL and parse it into JSON."""
+    """
+    Fetch the XML from the given URL and parse it into a dictionary.
+
+    Args:
+        url (str): The URL to fetch the XML from.
+
+    Returns:
+        dict or None: The parsed XML as a dictionary, or None if the request fails.
+    """
     try:
         response = requests.get(url)
         response.raise_for_status()
@@ -202,7 +225,15 @@ def fetch_and_parse_xml(url):
 
 
 def xml_to_dict(element):
-    """Convert an XML element and its children into a dictionary."""
+    """
+    Convert an XML element and its children into a dictionary.
+
+    Args:
+        element (xml.etree.ElementTree.Element): The XML element to convert.
+
+    Returns:
+        dict or str: The element and its children as a dictionary, or the text if it has no children.
+    """
     def strip_ns(tag):
         return tag.split('}', 1)[-1] if '}' in tag else tag
 
@@ -213,7 +244,15 @@ def xml_to_dict(element):
 
 
 def parse_device_info(device_info):
-    """Parse the device info string into a dictionary."""
+    """
+    Parsee the device info string into a dictionary.
+
+    Args:
+        device_info (str): The device info string, typically an SSDP response.
+
+    Returns:
+        dict: The parsed device info as a dictionary.
+    """
     info_dict = {}
     lines = device_info.split("\r\n")
     for line in lines:
@@ -225,8 +264,15 @@ def parse_device_info(device_info):
 
 
 def discover_upnp_devices(timeout=5):
-    """Discover UPnP devices using SSDP. Returns an iterator of device_dict."""
+    """
+    Discover UPnP devices using SSDP.
 
+    Args:
+        timeout (int, optional): The socket timeout in seconds. Defaults to 5.
+
+    Returns:
+        Iterator[dict]: An iterator of discovered device dictionaries.
+    """
     # Set to store the IP addresses of discovered devices
     device_ip_set = set()
 

--- a/src/libinspector/ssdp_discovery.py
+++ b/src/libinspector/ssdp_discovery.py
@@ -196,7 +196,7 @@ def fetch_and_parse_xml(url):
         xml_content = response.content
         root = ET.fromstring(xml_content)
         return xml_to_dict(root)
-    except requests.RequestException as e:
+    except requests.RequestException:
         return None
 
 

--- a/src/libinspector/tls_processor.py
+++ b/src/libinspector/tls_processor.py
@@ -9,8 +9,17 @@ from scapy.layers.tls.handshake import TLSClientHello
 
 def extract_sni(packet) -> str:
     """
-    Returns the SNI of a packet.
+    Return the Server Name Indication (SNI) from a TLS packet, or an empty string if not present.
 
+    This function inspects the given packet for a TLSClientHello layer and attempts to extract the SNI
+    (Server Name Indication) extension, which indicates the hostname the client is attempting to connect to.
+    If the SNI extension is not found or the packet does not contain a TLSClientHello, an empty string is returned.
+
+    Args:
+        packet: The packet object to inspect, expected to be a Scapy packet.
+
+    Returns:
+        str: The extracted SNI as a string, or an empty string if not found.
     """
     try:
         tls_layer = packet[TLSClientHello] # type: ignore

--- a/src/libinspector/tls_processor.py
+++ b/src/libinspector/tls_processor.py
@@ -4,7 +4,7 @@ Functions for processing the TLS layer in packets.
 This module is in a separate file because I don't want `from scapy.all import *` (required for `TLSClientHello`) to pollute the namespace.
 
 """
-from scapy.all import *
+from scapy.layers.tls.handshake import TLSClientHello
 
 
 def extract_sni(packet) -> str:

--- a/src/run_tests.py
+++ b/src/run_tests.py
@@ -4,7 +4,6 @@ import sys
 
 
 def main():
-
     # Make sure we're running as root
     if os.geteuid() != 0:
         print('All tests must be run as root. Exiting.')
@@ -15,7 +14,6 @@ def main():
 
     runner = unittest.TextTestRunner(verbosity=2)
     runner.run(suite)
-
 
 
 if __name__ == '__main__':

--- a/src/tests/test_networking.py
+++ b/src/tests/test_networking.py
@@ -5,6 +5,18 @@ import libinspector.common as common
 import libinspector.networking as networking
 
 
+def cidr_to_netmask(cidr_prefix):
+    """Converts a CIDR prefix to a dotted-decimal netmask."""
+    num_bits = int(cidr_prefix)
+    netmask_binary = '1' * num_bits + '0' * (32 - num_bits)
+
+    netmask_parts = []
+    for i in range(0, 32, 8):
+        byte_binary = netmask_binary[i:i + 8]
+        netmask_parts.append(str(int(byte_binary, 2)))
+    return ".".join(netmask_parts)
+
+
 def run_command(command):
     """Run a shell command and return the output."""
     try:
@@ -13,41 +25,118 @@ def run_command(command):
     except subprocess.CalledProcessError as e:
         return f"Error: {e}"
 
+
 def get_default_interface():
     if common.get_os() == 'mac':
         command = "route get default | grep interface | awk '{print $2}'"
     elif common.get_os() == 'linux':
         command = "ip route show default | awk '/default/ {print $5}'"
+    elif common.get_os() == 'windows':
+        # Step 1: Get the InterfaceIndex from the default route
+        powershell_command_ifindex = [
+            "powershell", "-NoProfile", "-Command",
+            "Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IfIndex"
+        ]
+        if_index = run_command(powershell_command_ifindex)
+
+        if not if_index:
+            raise Exception("No default route found on Windows. Essentially, no interface has a default route (0.0.0.0/0).")
+
+        # Step 2: Use the InterfaceIndex to get the InterfaceGuid
+        powershell_command_alias = [
+            "powershell", "-NoProfile", "-Command",
+            f"(Get-NetAdapter -InterfaceIndex {if_index} | Select-Object -First 1).InterfaceGuid"
+        ]
+        raw_guid = run_command(powershell_command_alias)
+        interface_name = f"\\Device\\NPF_{raw_guid}"
+        return interface_name
     else:
         raise NotImplementedError(f"Unsupported OS: {common.get_os()}")
     return run_command(command)
+
 
 def get_router_ip(interface):
     if common.get_os() == 'mac':
         command = f"netstat -rn | grep default | grep {interface} | awk '{{print $2}}'"
     elif common.get_os() == 'linux':
         command = f"ip route show default | grep {interface} | awk '{{print $3}}'"
+    elif common.get_os() == 'windows':
+        # Step 1: Get the InterfaceIndex from the default route
+        powershell_command_ifindex = [
+            "powershell", "-NoProfile", "-Command",
+            "Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IfIndex"
+        ]
+        if_index = run_command(powershell_command_ifindex)
+
+        if not if_index:
+            raise Exception("No default route found on Windows. Essentially, no interface has a default route (0.0.0.0/0).")
+
+        # Step 2: Get the Default Gateway IP specifically
+        # The key here is to expand the NextHop property of the default gateway object
+        powershell_command_gateway = [
+            "powershell", "-NoProfile", "-Command",
+            f"(Get-NetRoute -DestinationPrefix '0.0.0.0/0' -InterfaceIndex {if_index} | Select-Object -First 1).NextHop"
+        ]
+        # This directly returns the IP as a string if a default route exists for that interface.
+        return run_command(powershell_command_gateway)
     else:
         raise NotImplementedError(f"Unsupported OS: {common.get_os()}")
     return run_command(command)
+
 
 def get_ip_address(interface):
     if common.get_os() == 'mac':
         command = f"ipconfig getifaddr {interface}"
     elif common.get_os() == 'linux':
         command = f"ip addr show {interface} | grep 'inet ' | awk '{{print $2}}' | cut -d'/' -f1"
+    elif common.get_os() == 'windows':
+        # Step 1: Get the InterfaceIndex from the default route
+        powershell_command_ifindex = [
+            "powershell", "-NoProfile", "-Command",
+            "Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IfIndex"
+        ]
+        if_index = run_command(powershell_command_ifindex)
+
+        if not if_index:
+            raise Exception("No default route found on Windows. Essentially, no interface has a default route (0.0.0.0/0).")
+
+        # Step 2: Get the local IP address for the interface
+        powershell_command_local_ip = [
+            "powershell", "-NoProfile", "-Command",
+            f"(Get-NetIPAddress -InterfaceIndex {if_index} -AddressFamily IPv4 | Select-Object -First 1).IPAddress"
+        ]
+        return run_command(powershell_command_local_ip)
     else:
         raise NotImplementedError(f"Unsupported OS: {common.get_os()}")
     return run_command(command)
+
 
 def get_mac_address(interface):
     if common.get_os() == 'mac':
         command = f"ifconfig {interface} | grep ether | awk '{{print $2}}'"
     elif common.get_os() == 'linux':
         command = f"ifconfig {interface} | grep ether | awk '{{print $2}}'"
+    elif common.get_os() == 'windows':
+        # Step 1: Get the InterfaceIndex from the default route
+        powershell_command_ifindex = [
+            "powershell", "-NoProfile", "-Command",
+            "Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IfIndex"
+        ]
+        if_index = run_command(powershell_command_ifindex)
+
+        if not if_index:
+            raise Exception("No default route found on Windows. Essentially, no interface has a default route (0.0.0.0/0).")
+
+        # Step 2: Get the MAC address for the interface
+        powershell_command_mac = [
+            "powershell", "-NoProfile", "-Command",
+            f"(Get-NetAdapter -InterfaceIndex {if_index} | Select-Object -First 1).MacAddress"
+        ]
+        return run_command(powershell_command_mac).replace("-", ":").lower()
     else:
         raise NotImplementedError(f"Unsupported OS: {common.get_os()}")
     return run_command(command)
+
 
 def get_netmask(interface):
     if common.get_os() == 'mac':
@@ -55,6 +144,25 @@ def get_netmask(interface):
     elif common.get_os() == 'linux':
         command = f"ifconfig {interface} | grep 'netmask' | awk '{{print $4}}'"
         return run_command(command)
+    elif common.get_os() == 'windows':
+        # Step 1: Get the InterfaceIndex from the default route
+        powershell_command_ifindex = [
+            "powershell", "-NoProfile", "-Command",
+            "Get-NetRoute -DestinationPrefix '0.0.0.0/0' | Sort-Object -Property InterfaceMetric | Select-Object -First 1 -ExpandProperty IfIndex"
+        ]
+        if_index = run_command(powershell_command_ifindex)
+
+        if not if_index:
+            raise Exception(
+                "No default route found on Windows. Essentially, no interface has a default route (0.0.0.0/0).")
+
+        # Step 2: Get the CIDR for the interface
+        powershell_command_local_ip = [
+            "powershell", "-NoProfile", "-Command",
+            f"(Get-NetIPAddress -InterfaceIndex {if_index} -AddressFamily IPv4 | Select-Object -First 1).PrefixLength"
+        ]
+        prefix = run_command(powershell_command_local_ip)
+        return cidr_to_netmask(prefix)
     else:
         raise NotImplementedError(f"Unsupported OS: {common.get_os()}")
     netmask_hex = run_command(command)

--- a/src/tests/test_networking.py
+++ b/src/tests/test_networking.py
@@ -1,6 +1,5 @@
 import unittest
 import subprocess
-import libinspector.core as core
 import libinspector.common as common
 import libinspector.networking as networking
 

--- a/src/tests/test_networking.py
+++ b/src/tests/test_networking.py
@@ -1,7 +1,14 @@
 import unittest
 import subprocess
+import sys
 import libinspector.common as common
 import libinspector.networking as networking
+
+
+# Make sure we're running as root
+if not common.is_admin():
+    print('All tests must be run as root. Exiting.')
+    sys.exit(1)
 
 
 def run_command(command):

--- a/src/tests/test_oui_parser.py
+++ b/src/tests/test_oui_parser.py
@@ -1,10 +1,9 @@
 import unittest
 from libinspector.oui_parser import get_vendor
 
+
 class TestOUIParser(unittest.TestCase):
-
     def test_get_vendor(self):
-
         self.assertEqual(get_vendor('74:F8:DB:E0:00:00'), 'Bernard Krone Holding GmbH & Co. KG')
         self.assertEqual(get_vendor('8C:1F:64:00:30:00'), 'Brighten Controls LLP')
         self.assertEqual(get_vendor('8C1E80000000'), 'Cisco Systems, Inc')


### PR DESCRIPTION
Hello Danny,
Based on the onboarding plan, I want to start here on some open source best practices changes:

1- Add CI/CD for the following
- Label GitHub Issues
- Create templates for pull requests and issues
- Run both linting with ruff and pytest on Pull Requests
- Create Wheel file for PyPi release, not fully rolled out, but we can finish this in another PR

2- Add Python Doc string for all methods and functions. You can now create the documentation running the command:

```bash
pdoc3 --html src/libinspector/
```

I used the command `pydocstyle src/libinspector/` after installing `pydocstyle` to help me find all places I can add docstring

3- Updated the repository to use pyproject.toml and create wheel files

4- Updated test cases to confirm that yes, it seems IoT inspector core does work well for Linux (Ubuntu), Windows and Mac based on current test suite. Testing to disable and enable port forwarding might not be ideal given GitHub avoids having root, but this is a win regardless now knowing this works