### PR TITLE
Fix - Remove warning

### DIFF
--- a/src/libinspector/arp_spoof.py
+++ b/src/libinspector/arp_spoof.py
@@ -161,23 +161,11 @@ def send_spoofed_arp(victim_mac_addr, victim_ip_addr, gateway_mac_addr, gateway_
             return
 
     # Send ARP spoof request to gateway, so that the gateway thinks that Inspector's host is the victim.
-
-    dest_arp = sc.ARP()
-    dest_arp.op = 2
-    dest_arp.psrc = victim_ip_addr
-    dest_arp.hwsrc = host_mac_addr
-    dest_arp.pdst = gateway_ip_addr
-    dest_arp.hwdst = gateway_mac_addr
-
-    sc.sendp(dest_arp, iface=global_state.host_active_interface, verbose=0)
+    dest_arp = sc.ARP(op=2, psrc=victim_ip_addr, hwsrc=host_mac_addr, pdst=gateway_ip_addr, hwdst=gateway_mac_addr)
+    dest_pkt = sc.Ether(src=host_mac_addr, dst=gateway_mac_addr) / dest_arp
+    sc.sendp(dest_pkt, iface=global_state.host_active_interface, verbose=0)
 
     # Send ARP spoof request to a victim so that the victim thinks that Inspector's host is the gateway.
-
-    victim_arp = sc.ARP()
-    victim_arp.op = 2
-    victim_arp.psrc = gateway_ip_addr
-    victim_arp.hwsrc = host_mac_addr
-    victim_arp.pdst = victim_ip_addr
-    victim_arp.hwdst = victim_mac_addr
-
-    sc.sendp(victim_arp, iface=global_state.host_active_interface, verbose=0)
+    victim_arp = sc.ARP(op=2, psrc=gateway_ip_addr, hwsrc=host_mac_addr, pdst=victim_ip_addr, hwdst=victim_mac_addr)
+    victim_pkt = sc.Ether(src=host_mac_addr, dst=victim_mac_addr) / victim_arp
+    sc.sendp(victim_pkt, iface=global_state.host_active_interface, verbose=0)

--- a/src/libinspector/ssdp_discovery.py
+++ b/src/libinspector/ssdp_discovery.py
@@ -221,9 +221,13 @@ def fetch_and_parse_xml(url):
         logger.warning(f"Request failed for {url}: {e}")
         return None
     except ET.ParseError as e:
-        logger.warning(f"XML parsing failed for {url}: {e}")
         if xml_content is not None:
-            logger.warning(f"XML content:\n {xml_content}")
+            decoded_content = xml_content.decode("utf-8", errors="ignore").strip()
+            if decoded_content != "status=ok":
+                logger.warning(f"XML content:\n {xml_content}")
+                logger.warning(f"XML parsing failed for {url}: {e}")
+        else:
+            logger.warning(f"XML parsing failed, and XML content is NOT populated {url}: {e}")
         return None
 
 


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every function this PR changes
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**
So I am trying to make sure we minimize/have no warnings, as these problems have a way of becoming worse when ignored.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3441008a-684c-43f9-990f-4ead356e5e61" />

This warning came from this change to [scapy](https://github.com/secdev/scapy/commit/97a49f32b99c2799d9e6a04969d2c66c231abd37)

At first I naively just changed from send to sendp() and broke IoT Inspector (yay, first prod outage? >.<)

But I noticed you had this code here, in arp_scanner.py

```python
        arp_pkt = sc.Ether(src=host_mac_addr, dst="ff:ff:ff:ff:ff:ff") / \
        sc.ARP(pdst=ip, hwsrc=host_mac_addr, hwdst="ff:ff:ff:ff:ff:ff")

        sc.sendp(arp_pkt, iface=host_active_interface, verbose=0)
```

Using AI, and that template, I updated the code to use sendp(), this should remove the warning, and more importantly, I think its best practice all ARP stuff is managed through Ethernet.

...

**Test plan**
Merge it to main and test if IoT Inspector captures packets.

...

**Closing issues**

N/A
...
