### PR TITLE
Fix ICMP Redirect Issue and more progress on SSDP and MDNS can ending gracefully

### DIFF
--- a/src/libinspector/arp_scanner.py
+++ b/src/libinspector/arp_scanner.py
@@ -24,13 +24,14 @@ Functions:
 """
 import scapy.all as sc
 import logging
+import threading
 from . import global_state
-
+from . import common
 
 logger = logging.getLogger(__name__)
 
 
-def start():
+def start(stop_event: threading.Event = None, run_event: threading.Event = None):
     """
     Perform an ARP scan over the configured IP range.
 
@@ -38,19 +39,23 @@ def start():
     Update the device's table and default routes as new devices are discovered.
     All devices in the IP range are inspected by default.
     """
-    # Obtain the IP range
+    if run_event:
+        run_event.wait()
+
+    if not common.inspector_is_running():
+        return
+
+    # Obtain the IP range, Host Mac and Host Interface
     with global_state.global_state_lock:
         ip_range = global_state.ip_range
+        host_mac_addr = global_state.host_mac_addr
+        host_active_interface = global_state.host_active_interface
 
     logger.info(f'[ARP Scanner] Scanning {len(ip_range)} IP addresses.')
 
     for ip in ip_range:
-        # What is the MAC address of the host running Inspector?
-        with global_state.global_state_lock:
-            host_mac_addr = global_state.host_mac_addr
-            host_active_interface = global_state.host_active_interface
-
+        if stop_event and stop_event.is_set():
+            break
         arp_pkt = sc.Ether(src=host_mac_addr, dst="ff:ff:ff:ff:ff:ff") / \
             sc.ARP(pdst=ip, hwsrc=host_mac_addr, hwdst="ff:ff:ff:ff:ff:ff")
-
         sc.sendp(arp_pkt, iface=host_active_interface, verbose=0)

--- a/src/libinspector/arp_spoof.py
+++ b/src/libinspector/arp_spoof.py
@@ -131,8 +131,7 @@ def send_spoofed_arp(victim_mac_addr: str, victim_ip_addr: str, gateway_mac_addr
     if not common.inspector_is_running():
         return
 
-    # Send ARP spoof request to gateway, so that the gateway thinks that Inspector's host is the victim.
-    # 2/15/2025: Some routers will block ARP spoofing attempts that claim to be from the gateway, so we make this optional via an environment variable.
+    # Enable control of ARP spoof direction, in case we have to worry about protections.
     if common.get_env_bool('ARP_SPOOF_ROUTER', True):
         logger.info("[arp_spoof] Sending ARP spoofing packet to gateway to impersonate victim")
         dest_arp = sc.ARP(op=2, psrc=victim_ip_addr, hwsrc=host_mac_addr, pdst=gateway_ip_addr, hwdst=gateway_mac_addr)

--- a/src/libinspector/global_state.py
+++ b/src/libinspector/global_state.py
@@ -112,3 +112,6 @@ packet_processor_thread: threading.Thread | None = None
 
 # Flag set after the initial network scan is complete.
 device_discovery_complete: bool = False
+
+# Track if ICMP Redirect is enabled or not
+icmp_redirect_enabled : str = "unknown"

--- a/src/libinspector/mdns_discovery.py
+++ b/src/libinspector/mdns_discovery.py
@@ -250,6 +250,12 @@ def get_mdns_devices(service_type_discovery_timeout: int = 10, device_discovery_
 
 
 def start(stop_event: threading.Event = None, run_event: threading.Event = None):
+    """
+    Start the discovery process, used by IoT Inspector within a Thread function
+    Args:
+        stop_event (threading.Event, optional): An event to signal early termination of discovery.
+        run_event (threading.Event, optional): An event to signal to pause this thread
+    """
     if run_event:
         run_event.wait()
 

--- a/src/libinspector/mdns_discovery.py
+++ b/src/libinspector/mdns_discovery.py
@@ -26,7 +26,9 @@ from zeroconf import Zeroconf, ServiceBrowser, ServiceListener
 import time
 import json
 import logging
+import threading
 from . import global_state
+from . import common
 
 logger = logging.getLogger(__name__)
 
@@ -83,20 +85,24 @@ class ServiceTypeListener(ServiceListener):
         print(f"[mDNS] [UPDATED SERVICE TYPE] {name}")
 
 
-def get_all_service_types(zeroconf: Zeroconf, timeout: int = 15) -> set:
+def get_all_service_types(zeroconf: Zeroconf, timeout: int = 15, stop_event: threading.Event = None) -> set:
     """
     Discover all available mDNS service types on the local network.
 
     Args:
         zeroconf (Zeroconf): An existing Zeroconf instance to use for service discovery.
         timeout (int, optional): Number of seconds to wait for service discovery. Defaults to 15.
-
+        stop_event (threading.Event, optional): An event to signal early termination of discovery. Defaults to None.
     Returns:
         set: A set of discovered mDNS service type names (str).
     """
     listener = ServiceTypeListener()
-    ServiceBrowser(zeroconf, "_services._dns-sd._udp.local.", listener)
-    time.sleep(timeout)
+    browser = ServiceBrowser(zeroconf, "_services._dns-sd._udp.local.", listener)
+
+    if smart_sleep(timeout, stop_event):
+        logger.info("[mDNS] Discovery aborted during service type scan.")
+
+    browser.cancel()
     return listener.service_types
 
 
@@ -195,20 +201,31 @@ def discover_mdns_devices(zeroconf: Zeroconf, service_type: str) -> MDNSDeviceLi
     return listener
 
 
-def get_mdns_devices(service_type_discovery_timeout: int = 10, device_discovery_timeout: int = 10):
+def smart_sleep(seconds: int, stop_event: threading.Event = None):
+    if stop_event:
+        return stop_event.wait(timeout=seconds)
+    else:
+        time.sleep(seconds)
+        return False
+
+
+def get_mdns_devices(service_type_discovery_timeout: int = 10, device_discovery_timeout: int = 10, stop_event: threading.Event = None):
     """
     Discover devices using mDNS and group them by IP address.
 
     Args:
         service_type_discovery_timeout (int, optional): Seconds to wait for service type discovery. Defaults to 10.
         device_discovery_timeout (int, optional): Seconds to wait for device discovery per service type. Defaults to 10.
-
+        stop_event (threading.Event, optional): An event to signal early termination of discovery. Defaults to None.
     Returns:
         dict: A dictionary mapping device IP addresses (str) to a list of dictionaries,
         each containing 'device_name' and 'device_properties' for a discovered device.
     """
     with Zeroconf() as zeroconf:
-        service_types = get_all_service_types(zeroconf, timeout=service_type_discovery_timeout)
+        service_types = get_all_service_types(zeroconf, timeout=service_type_discovery_timeout, stop_event=stop_event)
+
+        if stop_event and stop_event.is_set():
+            return {}
 
         listeners = []
         for service_type in service_types:
@@ -220,7 +237,7 @@ def get_mdns_devices(service_type_discovery_timeout: int = 10, device_discovery_
                 logger.error(f"Failed to browse {service_type}: {e}")
                 continue
 
-        time.sleep(device_discovery_timeout)
+        smart_sleep(device_discovery_timeout, stop_event)
 
         device_dictionary = dict()
         for listener in listeners:
@@ -232,11 +249,16 @@ def get_mdns_devices(service_type_discovery_timeout: int = 10, device_discovery_
         return device_dictionary
 
 
-def start():
+def start(stop_event: threading.Event = None, run_event: threading.Event = None):
+    if run_event:
+        run_event.wait()
+
+    if not common.inspector_is_running():
+        return
+
     logger.info("[mDNS] Discovering devices...")
 
-    # Parse the output of the subprocess
-    device_dict = get_mdns_devices()
+    device_dict = get_mdns_devices(stop_event=stop_event)
 
     # Add the discovered devices to the database
     conn, rw_lock = global_state.db_conn_and_lock

--- a/src/libinspector/networking.py
+++ b/src/libinspector/networking.py
@@ -36,7 +36,7 @@ import netaddr
 import logging
 import psutil
 import sys
-
+import re
 from . import global_state
 from . import common
 
@@ -298,50 +298,100 @@ def is_ipv4_addr(ip_string: str) -> bool:
         return False
 
 
-def enable_ip_forwarding():
+def get_actual_icmp_redirect_state():
     """
-    Enable IP forwarding on the host system.
-
-    This function enables IP forwarding (routing) at the OS level, allowing the host to forward packets between interfaces.
-    Exits the program if the operation fails.
+    Retrieves the current ICMP redirect state for Windows, Mac, or Linux.
+    CRASHES if the state cannot be determined to protect config integrity.
     """
     os_platform = common.get_os()
 
-    if os_platform == 'mac':
-        cmd = ['/usr/sbin/sysctl', '-w', 'net.inet.ip.forwarding=1']
-    elif os_platform == 'linux':
-        cmd = ['sysctl', '-w', 'net.ipv4.ip_forward=1']
-    elif os_platform == 'windows':
-        cmd = ['powershell', 'Set-NetIPInterface', '-Forwarding', 'Enabled']
-    else:
-        logger.error(f'[networking] Unsupported OS platform: {os_platform}. Cannot enable IP forwarding.')
-        raise RuntimeError(f'[networking] Unsupported OS platform: {os_platform}. Cannot enable IP forwarding.')
+    if os_platform == 'windows':
+        # Output looks like: "ICMP Redirects : enabled"
+        output = subprocess.check_output(['netsh', 'interface', 'ipv4', 'show', 'global'], text=True)
+        match = re.search(r'ICMP Redirects\s*:\s*(\w+)', output)
+        if not match:
+            raise RuntimeError("Could not parse Windows ICMP state from netsh.")
+        return match.group(1).lower()  # 'enabled' or 'disabled'
 
-    if subprocess.call(cmd) != 0:
-        logger.error('[networking] Failed to enable IP forwarding.')
-        raise RuntimeError('[networking] Failed to enable IP forwarding.')
+    elif os_platform == 'linux':
+        # Output looks like: "net.ipv4.conf.all.send_redirects = 1"
+        output = subprocess.check_output(['sysctl', 'net.ipv4.conf.all.send_redirects'], text=True)
+        match = re.search(r'=\s*(\d)', output)
+        if not match:
+            raise RuntimeError("Could not parse Linux send_redirects state.")
+        # 1 is enabled, 0 is disabled
+        return "enabled" if match.group(1) == "1" else "disabled"
+
+    elif os_platform == 'mac':
+        # Output looks like: "net.inet.icmp.drop_redirect: 0"
+        # NOTE: drop_redirect=1 means redirects are DISABLED (dropped).
+        output = subprocess.check_output(['sysctl', 'net.inet.icmp.drop_redirect'], text=True)
+        match = re.search(r':\s*(\d)', output)
+        if not match:
+            raise RuntimeError("Could not parse Mac drop_redirect state.")
+        return "disabled" if match.group(1) == "1" else "enabled"
+
+    else:
+        raise OSError(f"Unsupported OS platform: {os_platform}")
+
+
+def enable_ip_forwarding():
+    """
+    Enables IP forwarding and silences ICMP redirects.
+    Uses check_call to ensure the program crashes if setup fails.
+    """
+    os_platform = common.get_os()
+
+    # 1. Capture original state before we touch anything
+    original_icmp_state = get_actual_icmp_redirect_state()
+    with global_state.global_state_lock:
+        global_state.icmp_redirect_enabled = original_icmp_state
+    logger.info(f"[networking] Original ICMP state detected as: {original_icmp_state}")
+
+    cmds = []
+    if os_platform == 'mac':
+        cmds.append(['sysctl', '-w', 'net.inet.ip.forwarding=1'])
+        cmds.append(['sysctl', '-w', 'net.inet.icmp.drop_redirect=1'])
+    elif os_platform == 'linux':
+        cmds.append(['sysctl', '-w', 'net.ipv4.ip_forward=1'])
+        cmds.append(['sysctl', '-w', 'net.ipv4.conf.all.send_redirects=0'])
+    elif os_platform == 'windows':
+        cmds.append(['powershell', 'Set-NetIPInterface', '-Forwarding', 'Enabled'])
+        cmds.append(['netsh', 'interface', 'ipv4', 'set', 'global', 'icmpredirects=disabled'])
+        cmds.append(['netsh', 'interface', 'ipv6', 'set', 'global', 'icmpredirects=disabled'])
+    else:
+        raise NotImplementedError(f"Unsupported OS platform: {os_platform}")
+
+    for cmd in cmds:
+        logger.info(f"[networking] Setting up: {' '.join(cmd)}")
+        subprocess.check_call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
 
 
 def disable_ip_forwarding():
     """
-    Disable IP forwarding on the host system.
-
-    This function disables IP forwarding (routing) at the OS level, preventing the host from forwarding packets between interfaces.
-    Exits the program if the operation fails.
+    Restores original system state.
     """
     os_platform = common.get_os()
+    with global_state.global_state_lock:
+        original_icmp_state = global_state.icmp_redirect_enabled
 
+    cmds = []
     if os_platform == 'mac':
-        cmd = ['/usr/sbin/sysctl', '-w', 'net.inet.ip.forwarding=0']
+        cmds.append(['sysctl', '-w', 'net.inet.ip.forwarding=0'])
+        # If it was enabled (0), set drop back to 0. If it was disabled (1), set to 1.
+        val = '1' if original_icmp_state == 'disabled' else '0'
+        cmds.append(['sysctl', '-w', f'net.inet.icmp.drop_redirect={val}'])
     elif os_platform == 'linux':
-        cmd = ['sysctl', '-w', 'net.ipv4.ip_forward=0']
+        cmds.append(['sysctl', '-w', 'net.ipv4.ip_forward=0'])
+        val = '0' if original_icmp_state == 'disabled' else '1'
+        cmds.append(['sysctl', '-w', f'net.ipv4.conf.all.send_redirects={val}'])
     elif os_platform == 'windows':
-        cmd = ['powershell', 'Set-NetIPInterface', '-Forwarding', 'Disabled']
+        cmds.append(['powershell', 'Set-NetIPInterface', '-Forwarding', 'Disabled'])
+        cmds.append(['netsh', 'interface', 'ipv4', 'set', 'global', f'icmpredirects={original_icmp_state}'])
+        cmds.append(['netsh', 'interface', 'ipv6', 'set', 'global', f'icmpredirects={original_icmp_state}'])
     else:
-        logger.error(f'[networking] Unsupported OS platform: {os_platform}. Cannot disable IP forwarding.')
-        raise RuntimeError(f'[networking] Unsupported OS platform: {os_platform}. Cannot disable IP forwarding.')
+        raise NotImplementedError(f"Unsupported OS platform: {os_platform}")
 
-    if subprocess.call(cmd) != 0:
-        logger.error('[networking] Failed to disable IP forwarding.')
-        raise RuntimeError('[networking] Failed to disable IP forwarding.')
-
+    for cmd in cmds:
+        logger.info(f"[networking] Cleaning up: {' '.join(cmd)}")
+        subprocess.call(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)

--- a/src/libinspector/oui_parser.py
+++ b/src/libinspector/oui_parser.py
@@ -65,9 +65,6 @@ def parse_ieee_oui_database_from_local_csv():
         - Populates the global `_oui_dict` with OUI-to-company mappings, clearing any old data.
         - Populates the global `_oui_length_split_list` with sorted OUI prefix lengths,
           clearing any old data.
-
-    Returns:
-        None
     """
     # Clear existing data to avoid conflicts with other database parsers
     _oui_dict.clear()

--- a/src/libinspector/packet_processor.py
+++ b/src/libinspector/packet_processor.py
@@ -54,7 +54,8 @@ def process_packet_helper(pkt: sc.Packet):
     """
     Process a captured network packet and dispatch it to the appropriate handler.
 
-    This function first checks for a custom packet callback and executes it if present, logging any exceptions. It then determines the packet type and processes it accordingly:
+    This function first checks for a custom packet callback and executes it if present, logging any exceptions.
+    It then determines the packet type and processes it accordingly:
     - ARP and DHCP packets are handled by their respective functions and processing stops.
     - Packets without both Ethernet and IP layers are ignored.
     - Packets involving the Inspector host's own IP address are ignored.
@@ -115,7 +116,11 @@ def process_arp(pkt: sc.Packet):
     """
     Process an ARP packet to update the ARP cache and device information in the database.
 
-    This function handles ARP request and reply packets, ignoring those sent by the Inspector host or with a source IP of 0.0.0.0. It determines if the ARP entry corresponds to the network gateway and updates or inserts the device's MAC and IP address in the `devices` table, along with a timestamp and gateway status. Afterward, it updates the device's metadata with the OUI vendor if not already present.
+    This function handles ARP request and reply packets, ignoring those sent by the Inspector
+    host or with a source IP of 0.0.0.0. It determines if the ARP entry corresponds to the
+    network gateway and updates or inserts the device's MAC and IP address in the `devices` table,
+    along with a timestamp and gateway status. Afterward, it updates the device's metadata
+    with the OUI vendor if not already present.
 
     Args:
         pkt: The ARP packet (scapy packet) to process.
@@ -167,7 +172,13 @@ def process_dns(pkt: sc.Packet):
     """
     Process a DNS packet to extract the querying device, hostname, and associated IP addresses.
 
-    This code determines which device made the DNS request or response by comparing MAC addresses with the Inspector host. It ensures the device is not the gateway and extracts the queried hostname from the DNS question section, removing any trailing dot. If the packet contains DNS answers, it collects all IPv4 addresses from A records. If no IP addresses are found, an empty string is used. The extracted device MAC address, hostname, and set of IP addresses are then recorded in the database for tracking DNS activity.
+    This code determines which device made the DNS request or response by comparing MAC addresses
+    with the Inspector host. It ensures the device is not the gateway and extracts the queried hostname
+    from the DNS question section, removing any trailing dot. If the packet contains DNS answers,
+    it collects all IPv4 addresses from A records.
+
+    If no IP addresses are found, an empty string is used. The extracted device MAC address,
+    hostname, and set of IP addresses are then recorded in the database for tracking DNS activity.
 
     Args:
         pkt: The network packet (scapy packet) containing the DNS data.
@@ -230,7 +241,11 @@ def write_hostname_ip_mapping_to_db(device_mac_addr: str, hostname: str, ip_set:
     """
     Insert or update hostname-to-IP mappings in the `hostnames` table and log the operation.
 
-    This code iterates over a set of IP addresses and, for each, inserts a new record or updates an existing one in the `hostnames` database table with the provided hostname, current timestamp, and data source. The operation is performed within a write lock to ensure thread safety. After updating the database, it logs the mapping of the device's MAC address, hostname, and associated IP addresses for traceability.
+    This code iterates over a set of IP addresses and, for each, inserts a new record or updates
+    an existing one in the `hostnames` database table with the provided hostname, current timestamp,
+    and data source. The operation is performed within a write lock to ensure thread safety.
+    After updating the database, it logs the mapping of the device's MAC address, hostname,
+    and associated IP addresses for traceability.
 
     Args:
         ip_set (set): Set of IP addresses to associate with the hostname.
@@ -260,7 +275,16 @@ def process_flow(pkt: sc.Packet):
     """
     Process a TCP or UDP packet and update the `network_flows` table with flow information.
 
-    This function inspects the given packet to determine if it contains a TCP or UDP layer. It extracts relevant flow details such as source and destination MAC addresses, IP addresses, ports, and the TCP sequence number (if applicable). The function ensures the packet is not a broadcast and that the Inspector host is involved in the communication, updating MAC addresses as needed to reflect the actual device or gateway. It then inserts or updates a record in the `network_flows` database table, incrementing byte and packet counts and updating TCP sequence number metadata. After updating the flow, it triggers a refresh of hostnames in the flow records to ensure the most current hostname information is associated with each flow.
+    This function inspects the given packet to determine if it contains a TCP or UDP layer.
+    It extracts relevant flow details such as source and destination MAC addresses, IP addresses,
+    ports, and the TCP sequence number (if applicable). The function ensures the packet is not a
+    broadcast and that the Inspector host is involved in the communication, updating MAC addresses
+    as needed to reflect the actual device or gateway. It then inserts or updates a record in
+    the `network_flows` database table, incrementing byte and packet counts and updating TCP sequence
+    number metadata.
+
+    After updating the flow, it triggers a refresh of hostnames in the flow records to ensure
+    the most current hostname information is associated with each flow.
 
     Args:
         pkt: The network packet (scapy packet) to process.
@@ -342,9 +366,17 @@ def process_flow(pkt: sc.Packet):
 
 def update_hostnames_in_flows():
     """
-    Update the `network_flows` table by replacing IP addresses with corresponding hostnames from the `hostnames` table.
+    Update the `network_flows` table by replacing IP addresses with
+    corresponding hostnames from the `hostnames` table.
 
-    This function runs at most once every 2 seconds. It checks if enough time has passed since the last update, and if so, it acquires a database lock and executes an SQL statement to update the `src_hostname` and `dest_hostname` fields in the `network_flows` table. The update is performed only for flows where either the source or destination hostname is missing and a matching IP-to-hostname mapping exists in the `hostnames` table. After the update, the function records the current timestamp and logs the number of rows affected. This ensures that the flow records reflect the most recent hostname information for easier analysis and tracking.
+    It acquires a database lock and executes an SQL statement to update the `src_hostname` and
+    `dest_hostname` fields in the `network_flows` table. The update is performed only for flows
+    where either the source or destination hostname is missing and a matching IP-to-hostname mapping
+    exists in the `hostnames` table.
+
+    After the update, the function records the current timestamp and logs the number of rows affected.
+    This ensures that the flow records reflect the most recent hostname information for easier analysis
+    and tracking.
     """
     conn, rw_lock = global_state.db_conn_and_lock
     row_count = 0
@@ -385,7 +417,12 @@ def process_dhcp(pkt: sc.Packet):
 
     This function checks if the given packet is a DHCP Request broadcast.
     If so, it attempts to extract the hostname from the DHCP options.
-    If a valid hostname is found and the packet is not a response from the Inspector host itself, the function updates the devices table in the database with the device's MAC address, IP address, and hostname information. This enables tracking of devices and their hostnames on the network. If the packet does not meet these criteria or an error occurs during extraction, the function returns without making changes.
+    If a valid hostname is found and the packet is not a response from the Inspector host itself,
+    the function updates the devices table in the database with the device's MAC address, IP address,
+    and hostname information. This enables tracking of devices and their hostnames on the network.
+
+    If the packet does not meet these criteria or an error occurs during extraction,
+    the function returns without making changes.
 
     Args:
         pkt: The network packet (scapy packet) to process.
@@ -432,9 +469,16 @@ def process_dhcp(pkt: sc.Packet):
 
 def process_client_hello(pkt: sc.Packet):
     """
-    Extract the Server Name Indication (SNI) from a TLS ClientHello packet and updates the database with the mapping.
+    Extract the Server Name Indication (SNI) from a TLS ClientHello packet and updates the database
+    with the mapping.
 
-    This function processes a network packet to determine if it is destined for the Inspector host. If so, it attempts to extract the SNI field from the TLS ClientHello handshake. When an SNI is found, it is converted to lowercase and associated with the source device's MAC address and the remote IP address. This information is then recorded in the database, allowing tracking of which devices are attempting to connect to which hostnames. If the packet is not destined for the Inspector host or does not contain an SNI, no action is taken.
+    This function processes a network packet to determine if it is destined for the Inspector host.
+    If so, it attempts to extract the SNI field from the TLS ClientHello handshake.
+    When an SNI is found, it is converted to lowercase and associated with the
+    source device's MAC address and the remote IP address. This information is then
+    recorded in the database, allowing tracking of which devices are attempting to connect
+    to which hostnames. If the packet is not destined for the Inspector host or does not contain
+    an SNI, no action is taken.
 
     Args:
         pkt: The network packet (scapy packet) to process.

--- a/src/libinspector/packet_processor.py
+++ b/src/libinspector/packet_processor.py
@@ -347,7 +347,7 @@ def update_hostnames_in_flows():
     This function runs at most once every 2 seconds. It checks if enough time has passed since the last update, and if so, it acquires a database lock and executes an SQL statement to update the `src_hostname` and `dest_hostname` fields in the `network_flows` table. The update is performed only for flows where either the source or destination hostname is missing and a matching IP-to-hostname mapping exists in the `hostnames` table. After the update, the function records the current timestamp and logs the number of rows affected. This ensures that the flow records reflect the most recent hostname information for easier analysis and tracking.
     """
     conn, rw_lock = global_state.db_conn_and_lock
-
+    row_count = 0
     with rw_lock:
         sql = '''
             UPDATE network_flows

--- a/src/libinspector/safe_loop.py
+++ b/src/libinspector/safe_loop.py
@@ -11,6 +11,7 @@ SafeLoopThread(my_func, args=['a'], kwargs={'b': 2}, sleep_time=1)
 """
 import threading
 import logging
+import inspect
 from typing import Callable
 
 
@@ -108,6 +109,20 @@ class SafeLoopThread(object):
                 break
             try:
                 self._func(*self._func_args, **self._func_kwargs)
+                parameters = inspect.signature(self._func).parameters
+
+                # Build the kwargs to inject
+                extra_kwargs = {}
+                if 'stop_event' in parameters:
+                    extra_kwargs['stop_event'] = self._stop_event
+                if 'run_event' in parameters:
+                    extra_kwargs['run_event'] = self._run_event
+
+                # Merge with existing user-provided kwargs
+                final_kwargs = {**self._func_kwargs, **extra_kwargs}
+
+                # Execute the function
+                self._func(*self._func_args, **final_kwargs)
             except Exception:
                 logger.exception(f"[SafeLoopThread] Crash in {self.name} ({self._func.__name__}) "
                                  f"with args={self._func_args} kwargs={self._func_kwargs}")

--- a/src/libinspector/safe_loop.py
+++ b/src/libinspector/safe_loop.py
@@ -84,9 +84,11 @@ class SafeLoopThread(object):
         self._run_event.set()
 
     def join(self, timeout: int = None):
+        """Join the SafeLoop Thread"""
         self._thread.join(timeout)
 
     def is_alive(self):
+        """Confirm if the Thread is alive"""
         return self._thread.is_alive()
 
     def _execute_repeated_func_safe(self):

--- a/src/libinspector/ssdp_discovery.py
+++ b/src/libinspector/ssdp_discovery.py
@@ -249,8 +249,7 @@ def parse_device_info(device_info: str) -> dict:
         dict: The parsed device info as a dictionary.
     """
     info_dict = {}
-    lines = device_info.split("\r\n")
-    for line in lines:
+    for line in device_info.split("\r\n"):
         if ": " in line:
             key, value = line.split(": ", 1)
             info_dict[key] = value
@@ -308,14 +307,9 @@ def discover_upnp_devices(timeout: int = 5, stop_event: threading.Event = None, 
 
                 device_dict = {
                     'device_ip_addr': device_ip_addr,
-                    'ssdp_response_dict': None,
+                    'ssdp_response_dict': parse_device_info(ssdp_response),
                     'location_contents': None
                 }
-
-                try:
-                    device_dict["ssdp_response_dict"] = parse_device_info(ssdp_response)
-                except Exception:
-                    pass
 
                 if "LOCATION" in device_dict["ssdp_response_dict"]:
                     xml_json = fetch_and_parse_xml(device_dict["ssdp_response_dict"]["LOCATION"])

--- a/src/libinspector/ssdp_discovery.py
+++ b/src/libinspector/ssdp_discovery.py
@@ -135,14 +135,16 @@ import json
 import logging
 import time
 import argparse
+import threading
 from typing import Iterator
 from . import global_state
+from . import common
 
 
 logger = logging.getLogger(__name__)
 
 
-def start():
+def start(stop_event: threading.Event = None, run_event: threading.Event = None):
     """
     Start the SSDP discovery process and update the device database with discovered devices.
 
@@ -154,7 +156,8 @@ def start():
         - Updates the `devices` table in the database with discovered device information.
         - Logs discovered devices using the module logger.
     """
-    conn, rw_lock = global_state.db_conn_and_lock
+    if not common.inspector_is_running():
+        return
 
     # Set the socket timeout based on when the Inspector started; shorter
     # timeout when Inspector has started for 5 minutes for more aggressive
@@ -166,8 +169,8 @@ def start():
         else:
             socket_timeout = 30
 
-    for discovered_device_dict in discover_upnp_devices(timeout=socket_timeout):
-
+    conn, rw_lock = global_state.db_conn_and_lock
+    for discovered_device_dict in discover_upnp_devices(timeout=socket_timeout, stop_event=stop_event, run_event=run_event):
         if not discovered_device_dict:
             continue
 
@@ -254,13 +257,14 @@ def parse_device_info(device_info: str) -> dict:
     return info_dict
 
 
-def discover_upnp_devices(timeout: int = 5) -> Iterator[dict]:
+def discover_upnp_devices(timeout: int = 5, stop_event: threading.Event = None, run_event: threading.Event = None) -> Iterator[dict]:
     """
     Discover UPnP devices using SSDP.
 
     Args:
         timeout (int, optional): The socket timeout in seconds. Defaults to 5.
-
+        stop_event (threading.Event, optional): An event to signal stopping the discovery process. Defaults to None.
+        run_event (threading.Event, optional): An event to control pausing and resuming the discovery process. Defaults to None.
     Returns:
         Iterator[dict]: An iterator of discovered device dictionaries.
     """
@@ -277,17 +281,22 @@ def discover_upnp_devices(timeout: int = 5) -> Iterator[dict]:
 
     # Set to store the IP addresses of discovered devices
     device_ip_set = set()
+    start_time = time.time()
 
     # Create a UDP socket with automatic resource management
     with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
         sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        sock.settimeout(timeout)
+        sock.settimeout(1.0)
 
         # Bind to a random port and send the SSDP discovery request
         sock.sendto(MSEARCH_MSG, (SSDP_ADDR, SSDP_PORT))
-
-        try:
-            while True:
+        while (time.time() - start_time) < timeout:
+            if stop_event and stop_event.is_set():
+                logger.info("[ssdp] Orderly shutdown triggered mid-discovery.")
+                return
+            if run_event:
+                run_event.wait()
+            try:
                 response, addr = sock.recvfrom(4096)
                 ssdp_response = response.decode("utf-8", errors="ignore")
                 device_ip_addr = addr[0]
@@ -307,16 +316,15 @@ def discover_upnp_devices(timeout: int = 5) -> Iterator[dict]:
                     device_dict["ssdp_response_dict"] = parse_device_info(ssdp_response)
                 except Exception:
                     pass
-                else:
-                    if "LOCATION" in device_dict["ssdp_response_dict"]:
-                        xml_json = fetch_and_parse_xml(device_dict["ssdp_response_dict"]["LOCATION"])
-                        if xml_json:
-                            device_dict['location_contents'] = xml_json
+
+                if "LOCATION" in device_dict["ssdp_response_dict"]:
+                    xml_json = fetch_and_parse_xml(device_dict["ssdp_response_dict"]["LOCATION"])
+                    if xml_json:
+                        device_dict['location_contents'] = xml_json
 
                 yield device_dict
-
-        except socket.timeout:
-            pass
+            except socket.timeout:
+                pass
 
 
 def main():


### PR DESCRIPTION
 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [X] I've documented or updated the documentation of every function this PR changes
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

1. After some pain and misery debugging the Amazon Echo, I did notice that gracefully killing threads did seem to improve the network, going back to normal faster after IoT Inspector's ARP spoofing is gone.

Figure I should go the extra mile and get more work done to get threads to die gracefully.

2. Also, I noticed an issue that dramatically killed the performance of IoT Inspector was potentially `ICMP Redirects`. Code has been updated to tell the Kernel not to perform ICMP redirects!

Long story short, ICMP Redirects cause confusion in the network, especially with ARP spoofing, leading to much higher TCP retransmission rates. See the attached ChatGPT conversation. Note that we avoid changing the registry, as that might introduce more problems; we just use `netsh` to temporarily turn it off (if it is on) and turn it back on if it is on.

<img alt="image" src="https://github.com/user-attachments/assets/062d239b-d8dd-4128-8b49-4f154d0f7b8d" />

```text
Danny> I'm right now teaching a class on network security, cybersecurity, and I've been demonstrating to my students how to do ARP spoofing. But when I'm doing ARP spoofing from Linux boxes, and I do the packet capture, I don't see any ICMP redirects, but when I'm doing ARP spoofing from a Windows machine, I'm seeing a ton of ICMP redirects. And whenever I see ICMP redirects, it seems that the performance of network on the victim devices seems to suffer. There's a lot of retransmission from TCP retransmission. So why is that going on and what is ICMP redirect?

ChatGPT > 

Great observation — what you’re seeing is a real and interesting artifact of how different operating systems implement packet forwarding during a man-in-the-middle (MITM) attack. Let’s break it down clearly.

1. What ICMP Redirect Is

ICMP Redirect is a control message defined in ICMP Type 5 that routers use to tell a host:

“You are sending traffic through me, but there is actually a better gateway you should use.”

In other words, a router informs a host that it should change its routing decision.

Typical legitimate scenario

Suppose a host sends packets to Router A:

Host → Router A → Router B → Destination

But Router A realizes the host could send packets directly to Router B.

Router A sends:

ICMP Redirect:
"Use Router B instead"

After that, the host updates its routing cache.

2. Why ICMP Redirect Happens During ARP Spoofing

When you perform ARP spoofing, your attacking machine usually becomes a fake router between two machines.

Typical setup:

Victim  →  Attacker  →  Real Router

Because of ARP poisoning:

Victim thinks:
Gateway MAC = Attacker MAC

So packets flow:

Victim → Attacker → Router → Internet

Now the attacker must forward packets.

This forwarding behavior is where OS differences appear.

3. Why Windows Generates ICMP Redirects

Windows networking stack tends to follow RFC router behavior more strictly when IP forwarding is enabled.

When Windows sees:

incoming packet from victim
destination = router on same subnet

it may conclude:

“The sender could have sent this packet directly to the router.”

So Windows sends:

ICMP Redirect:
"Next hop should be router"

This happens because:

Windows is acting like a router

It sees a suboptimal route

So it sends ICMP Redirect (Type 5) messages to the victim.

In packet capture you might see something like:

ICMP Redirect
Gateway: 192.168.1.1
Destination: 8.8.8.8
4. Why Linux Usually Does NOT Send Them

Linux kernels typically suppress ICMP redirects by default when forwarding packets unless specific conditions are met.

Linux sysctl parameters control this:

/proc/sys/net/ipv4/conf/*/send_redirects

Usually:

send_redirects = 0

especially when:

ip_forward = 1

This is done because Linux assumes:

If you turned on IP forwarding, you're intentionally routing traffic.

So Linux avoids telling hosts to bypass it.

5. Why ICMP Redirect Causes Network Problems

ICMP redirects create routing instability.

What happens on the victim:

Victim sends packet → attacker (because of ARP poisoning)

Attacker sends ICMP redirect

Victim updates routing cache

Victim now tries to send traffic directly to router

But ARP spoofing still says:

Router MAC = attacker MAC

So the routing logic becomes inconsistent.

Result:

Victim routing table keeps changing
ARP cache keeps changing

This causes:

TCP retransmissions

packet reordering

temporary routing loops

congestion window collapse

Which explains what you observed:

“Lots of TCP retransmission and degraded performance.”

6. Why This Happens More on Windows MITM Tools

Many Windows MITM tools:

enable IP forwarding

but do not disable ICMP redirects

So Windows behaves like a legitimate router trying to optimize routing.

Linux MITM tools usually explicitly disable redirects.

Example tools that do this:

ettercap

dsniff

bettercap

They typically run:

echo 0 > /proc/sys/net/ipv4/conf/all/send_redirects
7. How to Disable ICMP Redirects on Windows (for demo stability)

If you want your classroom demo to behave nicely.

Disable redirects.

Registry setting:

HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters
EnableICMPRedirect = 0

or disable routing redirect behavior via PowerShell / netsh.

8. Quick Visual Summary

Normal network:

Victim ─── Router ─── Internet

ARP spoof:

Victim ─── Attacker ─── Router ─── Internet

Windows forwarding behavior:

Victim → Attacker
Attacker → Router
Attacker → Victim : ICMP Redirect ("use router")

Victim becomes confused.

9. Why This Is Actually a Great Teaching Moment

This demonstrates three core security/networking ideas:

ARP spoofing works because ARP has no authentication

ICMP redirect can change host routing behavior

Operating systems implement routing differently

Students get to see real protocol interaction between ARP, ICMP, and TCP.

✅ If you'd like, I can also explain:

why ICMP redirect itself is a security vulnerability

how attackers can abuse ICMP redirect for traffic hijacking

why modern routers disable ICMP redirect by default

or show a simple Wireshark filter to demonstrate this clearly in class
```
...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Or what test cases you added. -->
Confirm CI/CD passes.

While I am still struggling to get MDNS and SSDP to reliably kill gracefully, I am starting to see these threads not hang, so it's progress!!!!

```text
2026-03-12 16:26:33,475 - INFO - [core] Stopping thread: networking
2026-03-12 16:26:33,476 - INFO - [core] Stopping thread: arp_scanner
2026-03-12 16:26:33,476 - INFO - [SafeLoopThread] === networking HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,477 - INFO - [core] Stopping thread: packet_collector
2026-03-12 16:26:33,477 - INFO - [SafeLoopThread] === arp_scanner HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,478 - INFO - [core] Stopping thread: packet_processor
2026-03-12 16:26:33,478 - INFO - [core] Stopping thread: Update Hostnames
2026-03-12 16:26:33,479 - INFO - [core] Stopping thread: arp_spoof
2026-03-12 16:26:33,479 - INFO - [SafeLoopThread] === Update Hostnames HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,479 - INFO - [core] Stopping thread: ssdp_discovery
2026-03-12 16:26:33,479 - INFO - [SafeLoopThread] === arp_spoof HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,479 - INFO - [core] Stopping thread: mdns_discovery
2026-03-12 16:26:33,480 - INFO - [packet_collector] Interval complete. Collected 2776 packets (~317.87 pkt/s)
2026-03-12 16:26:33,480 - INFO - [core] Stopping thread: Device API Thread
2026-03-12 16:26:33,480 - INFO - [SafeLoopThread] === packet_collector HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,480 - INFO - [core] Stopping thread: Device Label Thread
2026-03-12 16:26:33,480 - INFO - [SafeLoopThread] === Device API Thread HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,480 - INFO - [core] SUCCESS: Thread 'networking'
2026-03-12 16:26:33,481 - INFO - [core] SUCCESS: Thread 'arp_scanner'
2026-03-12 16:26:33,480 - INFO - [SafeLoopThread] === Device Label Thread HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,481 - INFO - [core] SUCCESS: Thread 'packet_collector'
2026-03-12 16:26:33,518 - INFO - [SafeLoopThread] === packet_processor HAS OFFICIALLY EXITED ===
2026-03-12 16:26:33,519 - INFO - [core] SUCCESS: Thread 'packet_processor'
2026-03-12 16:26:33,519 - INFO - [core] SUCCESS: Thread 'Update Hostnames'
2026-03-12 16:26:33,519 - INFO - [core] SUCCESS: Thread 'arp_spoof'
2026-03-12 16:26:34,520 - INFO - [core] HANGING: Thread 'ssdp_discovery'
2026-03-12 16:26:34,756 - INFO - [SafeLoopThread] === ssdp_discovery HAS OFFICIALLY EXITED ===
2026-03-12 16:26:35,533 - INFO - [core] HANGING: Thread 'mdns_discovery'
2026-03-12 16:26:35,533 - INFO - [core] SUCCESS: Thread 'Device API Thread'
2026-03-12 16:26:35,533 - INFO - [core] SUCCESS: Thread 'Device Label Thread'
2026-03-12 16:26:35,533 - INFO - [networking] Cleaning up: powershell Set-NetIPInterface -Forwarding Disabled
2026-03-12 16:26:36,252 - INFO - [networking] Cleaning up: netsh interface ipv4 set global icmpredirects=enabled
2026-03-12 16:26:36,308 - INFO - [networking] Cleaning up: netsh interface ipv6 set global icmpredirects=enabled
```

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->
closes #20 since ARP restoration occurs fast, and gracefully killing threads should do all the work sufficient to restore the routing table back to normal.

Yes, it is still a WIP, but it's mostly done, and honestly, it's more a cosmetic issue, especially given how much IoT Inspector proved on thread management.
...
